### PR TITLE
Enable branding environment variable inheritance.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
       - win-library_bin.patch           # [win]
 
 build:
-  number: 2
+  number: 3
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:
@@ -21,6 +21,8 @@ build:
     - bin/python3.5     # [unix]
   track_features:
     - vc14              # [win]
+  script_env:
+    - python_branding
 
 requirements:
   build:


### PR DESCRIPTION
Enable the recipe to inherit the `python_branding` environment variable for customisation within the  `brand_python.py` script.

https://github.com/conda-forge/python-feedstock/blob/master/recipe/brand_python.py#L36