### PR TITLE
Enable environment variable branding for python27.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,12 +16,14 @@ source:
       - win-library_bin.patch           # [win]
 
 build:
-  number: 0
+  number: 1
   no_link:
     - bin/python2.7     # [unix]
     - DLLs/_ctypes.pyd  # [win]
   track_features:
     - vc9               # [win]
+  script_env:
+    - python_branding
 
 requirements:
   build:


### PR DESCRIPTION
Enable the conda recipe to inherit the `python_branding` environment variable for customisation within the  `brand_python.py` script.

See https://github.com/conda-forge/python-feedstock/blob/2.7/recipe/brand_python.py#L36