### PR TITLE
Enable environment variable branding for python34.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,12 +13,14 @@ source:
       - win-library_bin.patch           # [win]
 
 build:
-  number: 1
+  number: 2
   no_link:
     - bin/python3.4     # [unix]
     - DLLs/_ctypes.pyd  # [win]
   track_features:
     - vc10              # [win]
+  script_env:
+    - python_branding
 
 requirements:
   build:


### PR DESCRIPTION
Enable the conda recipe to inherit the `python_branding` environment variable for customisation within the  `brand_python.py` script.

See https://github.com/conda-forge/python-feedstock/blob/3.4/recipe/brand_python.py#L36