### PR TITLE
enable-loadable-sqlite-extensions tag added

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,6 +8,7 @@ if [ `uname` == Darwin ]; then
     sed -i -e "s/@OSX_ARCH@/$ARCH/g" Lib/distutils/unixccompiler.py
     ./configure \
         --enable-ipv6 \
+        --enable-loadable-sqlite-extensions \
         --enable-shared \
         --prefix=$PREFIX \
         --with-ensurepip=no \

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -104,3 +104,8 @@ import ssl
 print('OPENSSL_VERSION:', ssl.OPENSSL_VERSION)
 if sys.platform != 'win32':
     assert '1.0.2h' in ssl.OPENSSL_VERSION
+
+# --enable-loadable-sqlite-extensions
+import sqlite3
+con = sqlite3.connect(":memory:")
+con.enable_load_extension(True)


### PR DESCRIPTION
it is my first pull request in conda-forge.
any advice is welcome.

The sqlite3 module is not built with loadable extension support by default, because some platforms (notably Mac OS X) have SQLite libraries which are compiled without this feature. To get loadable extension support, you must pass –enable-loadable-sqlite-extensions to configure (https://docs.python.org/3/library/sqlite3.html#f1).

maybe before set this parameter would be necessary do some kind of validation.