### PR TITLE
Keep test support (Python 2.7)

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -129,8 +129,12 @@ del %PREFIX%\libs\libeay.lib %PREFIX%\libs\sqlite3.lib %PREFIX%\libs\ssleay.lib
 del %PREFIX%\libs\libpython*.a
 xcopy /s /y %SRC_DIR%\Lib %PREFIX%\Lib\
 if errorlevel 1 exit 1
+
+:: Remove test data to save space.
 rd /s /q %PREFIX%\Lib\test
 if errorlevel 1 exit 1
+
+:: Remove ensurepip stubs.
 rd /s /q %PREFIX%\Lib\ensurepip
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -131,7 +131,16 @@ xcopy /s /y %SRC_DIR%\Lib %PREFIX%\Lib\
 if errorlevel 1 exit 1
 
 :: Remove test data to save space.
+:: Though keep `test_support` as some things use that.
+mkdir %PREFIX%\Lib\test_keep
+if errorlevel 1 exit 1
+move %PREFIX%\Lib\test\__init__.py %PREFIX%\Lib\test_keep\
+if errorlevel 1 exit 1
+move %PREFIX%\Lib\test\test_support.py %PREFIX%\Lib\test_keep\
+if errorlevel 1 exit 1
 rd /s /q %PREFIX%\Lib\test
+if errorlevel 1 exit 1
+move %PREFIX%\Lib\test_keep %PREFIX%\Lib\test
 if errorlevel 1 exit 1
 
 :: Remove ensurepip stubs.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,12 @@
 python ${RECIPE_DIR}/brand_python.py
 
 # Remove test data to save space.
+# Though keep `test_support` as some things use that.
+mkdir Lib/test_keep
+mv Lib/test/__init__.py Lib/test_keep/
+mv Lib/test/test_support.py Lib/test_keep/
 rm -rf Lib/test Lib/*/test
+mv Lib/test_keep Lib/test
 
 # Remove ensurepip stubs.
 rm -rf Lib/ensurepip

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,10 @@
 
 python ${RECIPE_DIR}/brand_python.py
 
+# Remove test data to save space.
 rm -rf Lib/test Lib/*/test
+
+# Remove ensurepip stubs.
 rm -rf Lib/ensurepip
 
 if [ `uname` == Darwin ]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
       - win-library_bin.patch           # [win]
 
 build:
-  number: 1
+  number: 2
   no_link:
     - bin/python2.7     # [unix]
     - DLLs/_ctypes.pyd  # [win]

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -82,6 +82,8 @@ import select
 import ssl
 import strop
 import time
+import test
+import test.test_support
 import unicodedata
 import zlib
 import gzip


### PR DESCRIPTION
Make sure `test.test_support` is kept on Python 2.7 as this is used by some packages to aid in running their test suites.