### PR TITLE
Keep test support (Python 3.5)

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -131,9 +131,12 @@ REM Populate the Lib directory
 del %PREFIX%\libs\libpython*.a
 xcopy /s /y %SRC_DIR%\Lib %PREFIX%\Lib\
 if errorlevel 1 exit 1
-REM Remove test data and ensurepip stubs to save space
+
+:: Remove test data to save space.
 rd /s /q %PREFIX%\Lib\test
 if errorlevel 1 exit 1
+
+:: Remove ensurepip stubs.
 rd /s /q %PREFIX%\Lib\ensurepip
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -133,7 +133,16 @@ xcopy /s /y %SRC_DIR%\Lib %PREFIX%\Lib\
 if errorlevel 1 exit 1
 
 :: Remove test data to save space.
+:: Though keep `support` as some things use that.
+mkdir %PREFIX%\Lib\test_keep
+if errorlevel 1 exit 1
+move %PREFIX%\Lib\test\__init__.py %PREFIX%\Lib\test_keep\
+if errorlevel 1 exit 1
+move %PREFIX%\Lib\test\support %PREFIX%\Lib\test_keep\
+if errorlevel 1 exit 1
 rd /s /q %PREFIX%\Lib\test
+if errorlevel 1 exit 1
+move %PREFIX%\Lib\test_keep %PREFIX%\Lib\test
 if errorlevel 1 exit 1
 
 :: Remove ensurepip stubs.

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -131,6 +131,11 @@ REM Populate the Lib directory
 del %PREFIX%\libs\libpython*.a
 xcopy /s /y %SRC_DIR%\Lib %PREFIX%\Lib\
 if errorlevel 1 exit 1
+REM Remove test data and ensurepip stubs to save space
+rd /s /q %PREFIX%\Lib\test
+if errorlevel 1 exit 1
+rd /s /q %PREFIX%\Lib\ensurepip
+if errorlevel 1 exit 1
 
 
 REM bytecode compile the standard library

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,11 @@
 ${SYS_PYTHON} ${RECIPE_DIR}/brand_python.py
 
 # Remove test data to save space.
+# Though keep `support` as some things use that.
+mkdir Lib/test_keep
+mv Lib/test/support Lib/test_keep/support
 rm -rf Lib/test Lib/*/test
+mv Lib/test_keep Lib/test
 
 # Remove ensurepip stubs.
 rm -rf Lib/ensurepip

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,8 +2,10 @@
 
 ${SYS_PYTHON} ${RECIPE_DIR}/brand_python.py
 
-# Remove test data and ensurepip stubs to save space
+# Remove test data to save space.
 rm -rf Lib/test Lib/*/test
+
+# Remove ensurepip stubs.
 rm -rf Lib/ensurepip
 
 if [ $(uname) == Darwin ]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - fd_setsize.patch                # [win]
 
 build:
-  number: 0
+  number: 1
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -63,6 +63,8 @@ import parser
 import pyexpat
 import select
 import time
+import test
+import test.support
 import unicodedata
 import zlib
 from os import urandom


### PR DESCRIPTION
Make sure `test.support` is kept on Python 3.5 as this is used by some packages to aid in running their test suites.

Edit: Also remove the rest of `test` on Python 3.5 as it appears this wasn't done previously, but is likely intended. Pulling this change from @jjhelmus's commit ( https://github.com/conda-forge/python-feedstock/commit/7dd96003d52158066ea4e4b2bb1002fb761e2c61 ).