### PR TITLE
Fixes for Windows GCC interop needed by RPy2 and (potentially) CVXOPT

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -21,7 +21,7 @@ cd ..
 
 
 REM Populate the root package directory
-for %%x in (python36.dll python.exe pythonw.exe) do (
+for %%x in (python36.dll python3.dll python.exe pythonw.exe) do (
     copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\%%x %PREFIX%
     if errorlevel 1 exit 1
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,9 +19,11 @@ source:
     # - https://bugs.python.org/issue28708
     # - https://github.com/zeromq/libzmq/issues/1165
     - fd_setsize.patch                # [win]
+    - mingw-w64--DMS_WINXX.patch
+    - win-msc_ver-1900.patch
 
 build:
-  number: 1
+  number: 2
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:

--- a/recipe/mingw-w64--DMS_WINXX.patch
+++ b/recipe/mingw-w64--DMS_WINXX.patch
@@ -1,0 +1,19 @@
+--- Lib/distutils/cygwinccompiler.py.orig	2017-05-09 23:32:15.046506800 +0100
++++ Lib/distutils/cygwinccompiler.py	2017-05-09 23:36:41.868962800 +0100
+@@ -299,9 +299,13 @@
+             raise CCompilerError(
+                 'Cygwin gcc cannot be used with --compiler=mingw32')
+ 
+-        self.set_executables(compiler='gcc -O -Wall',
+-                             compiler_so='gcc -mdll -O -Wall',
+-                             compiler_cxx='g++ -O -Wall',
++        if sys.maxsize == 2**31 - 1:
++            ms_win=' -DMS_WIN32'
++        else:
++            ms_win=' -DMS_WIN64'
++        self.set_executables(compiler='gcc -O -Wall'+ms_win,
++                             compiler_so='gcc -mdll -O -Wall'+ms_win,
++                             compiler_cxx='g++ -O -Wall'+ms_win,
+                              linker_exe='gcc',
+                              linker_so='%s %s %s'
+                                         % (self.linker_dll, shared_option,

--- a/recipe/win-msc_ver-1900.patch
+++ b/recipe/win-msc_ver-1900.patch
@@ -1,0 +1,12 @@
+--- Lib/distutils/cygwinccompiler.py	2016-10-13 19:28:33.557226300 +0100
++++ Lib/distutils/cygwinccompiler.py	2016-10-13 19:29:27.686231200 +0100
+@@ -82,6 +82,9 @@
+         elif msc_ver == '1600':
+             # VS2010 / MSVC 10.0
+             return ['msvcr100']
++        elif int(msc_ver) >= 1900:
++            # VS2015 / MSVC 14.0
++            return ['msvcr140']
+         else:
+             raise ValueError("Unknown MS Compiler version %s " % msc_ver)
+ 


### PR DESCRIPTION
Here you go @ocefpaf