### PR TITLE
build Python 2 with UCS-4 on darwin

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -26,7 +26,7 @@ if [ `uname` == Darwin ]; then
     ./configure \
         --enable-ipv6 \
         --enable-shared \
-        --enable-unicode=ucs2 \
+        --enable-unicode=ucs4 \
         --prefix=$PREFIX \
         --with-tcltk-includes="-I$PREFIX/include" \
         --with-tcltk-libs="-L$PREFIX/lib -ltcl8.5 -ltk8.5"


### PR DESCRIPTION
matches linux

Are there any downstream things this would break? It makes Python 2 unicode much more sensible (as it is on Linux already).