### PR TITLE
Fix Tcl/Tk to 8.6

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,7 +32,7 @@ fi
             --with-ensurepip=no \
             --prefix=$PREFIX \
             --with-tcltk-includes="-I$PREFIX/include" \
-            --with-tcltk-libs="-L$PREFIX/lib -ltcl8.5 -ltk8.5" \
+            --with-tcltk-libs="-L$PREFIX/lib -ltcl8.6 -ltk8.6" \
             --enable-loadable-sqlite-extensions
 
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     - do-not-download-externals.patch  # [win]
 
 build:
-  number: 2
+  number: 3
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/python-feedstock/pull/158 ).

Unfortunately we version Tcl/Tk in several places, which makes things kind of hard to update ATM. Don't have any good ideas about how to fix that yet, but am open to suggestions. For now this fixes a few things that were still on Tcl/Tk 8.5 to 8.6.