### PR TITLE
Resurrect test support for Python 2.7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,24 +35,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -132,10 +132,12 @@ xcopy /s /y %SRC_DIR%\Lib %PREFIX%\Lib\
 if errorlevel 1 exit 1
 
 :: Remove test data to save space.
-:: Though keep `test_support` as some things use that.
+:: Though keep `test.support` and `test_support` as some things use that.
 mkdir %PREFIX%\Lib\test_keep
 if errorlevel 1 exit 1
 move %PREFIX%\Lib\test\__init__.py %PREFIX%\Lib\test_keep\
+if errorlevel 1 exit 1
+move %PREFIX%\Lib\test\support %PREFIX%\Lib\test_keep\
 if errorlevel 1 exit 1
 move %PREFIX%\Lib\test\test_support.py %PREFIX%\Lib\test_keep\
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,9 +9,10 @@ find "${PREFIX}/lib" -name "libbz2*${SHLIB_EXT}*" | xargs rm -fv {}
 python ${RECIPE_DIR}/brand_python.py
 
 # Remove test data to save space.
-# Though keep `test_support` as some things use that.
+# Though keep `test.support` and `test_support` as some things use that.
 mkdir Lib/test_keep
 mv Lib/test/__init__.py Lib/test_keep/
+mv Lib/test/support Lib/test_keep/
 mv Lib/test/test_support.py Lib/test_keep/
 rm -rf Lib/test Lib/*/test
 mv Lib/test_keep Lib/test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
       - win-library_bin.patch           # [win]
       - 0017-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
 build:
-  number: 3
+  number: 4
   no_link:
     - bin/python2.7     # [unix]
     - DLLs/_ctypes.pyd  # [win]

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -80,6 +80,7 @@ import ssl
 import strop
 import time
 import test
+import test.support
 import test.test_support
 import unicodedata
 import zlib

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -80,6 +80,7 @@ import ssl
 import strop
 import time
 import test
+import test.test_support
 import unicodedata
 import zlib
 import gzip


### PR DESCRIPTION
Support for `test.test_support` in the Python 2.7 build was added in PR ( https://github.com/conda-forge/python-feedstock/pull/112 ) originally. In Python 2.7.14, `test.test_support` was changed to `test.support` with a stub to allow `test.test_support` to be still imported. However as we did not include both pieces this wasn't installed correctly and the test broken. Hence it was reverted in PR ( https://github.com/conda-forge/python-feedstock/pull/151 ). This fixes up `test.test_support` for Python 2.7 and adds a check for `test.support` as well.