### PR TITLE
add patch for windows gcc interop

### DIFF
--- a/recipe/0008-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
+++ b/recipe/0008-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
@@ -1,0 +1,36 @@
+From cdc0ad2f6d60011c8b1d7f88ae7af46d70f7b5d3 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Wed, 16 Aug 2017 13:23:40 +0100
+Subject: [PATCH 08/11] Win32: Fixes for Windows GCC interop needed by RPy2 and
+ CVXOPT
+
+We must pass -DMS_WIN32 or -DMS_WIN64
+---
+ Lib/distutils/cygwinccompiler.py | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/Lib/distutils/cygwinccompiler.py b/Lib/distutils/cygwinccompiler.py
+index 258e138b04..74d52c9c94 100644
+--- a/Lib/distutils/cygwinccompiler.py
++++ b/Lib/distutils/cygwinccompiler.py
+@@ -324,9 +324,14 @@ class Mingw32CCompiler (CygwinCCompiler):
+         else:
+             no_cygwin = ''
+ 
+-        self.set_executables(compiler='gcc%s -O -Wall' % no_cygwin,
+-                             compiler_so='gcc%s -mdll -O -Wall' % no_cygwin,
+-                             compiler_cxx='g++%s -O -Wall' % no_cygwin,
++        if tuple.__itemsize__ == 4:
++            ms_win=' -DMS_WIN32'
++        else:
++            ms_win=' -DMS_WIN64'
++
++        self.set_executables(compiler='gcc%s -O -Wall%s' % (no_cygwin, ms_win),
++                             compiler_so='gcc%s -mdll -O -Wall%s' % (no_cygwin, ms_win),
++                             compiler_cxx='g++%s -O -Wall%s' % (no_cygwin, ms_win),
+                              linker_exe='gcc%s' % no_cygwin,
+                              linker_so='%s%s %s %s'
+                                     % (self.linker_dll, no_cygwin,
+-- 
+2.13.6
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
       - osx-dist.patch                  # [osx and x86_64]
       - win-find_exe.patch              # [win]
       - win-library_bin.patch           # [win]
+      - 0008-Win32-Fixes-for-Windows-GCC-interop-needed-by-RPy2-a.patch
       - 0017-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
 build:
-  number: 4
+  number: 5
   no_link:
     - bin/python2.7     # [unix]
     - DLLs/_ctypes.pyd  # [win]


### PR DESCRIPTION
passes -DMS_WIN32 or -DMS_WIN64 to gcc on Windows

patch from:
https://github.com/AnacondaRecipes/python-feedstock/tree/master-2.7