### PR TITLE
restore ensurepip

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -162,10 +162,6 @@ if errorlevel 1 exit 1
 move %PREFIX%\Lib\test_keep %PREFIX%\Lib\test
 if errorlevel 1 exit 1
 
-:: Remove ensurepip stubs.
-rd /s /q %PREFIX%\Lib\ensurepip
-if errorlevel 1 exit 1
-
 REM bytecode compile the standard library
 
 rd /s /q %PREFIX%\Lib\lib2to3\tests\

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -15,9 +15,6 @@ mv Lib/test/support Lib/test_keep/support
 rm -rf Lib/test Lib/*/test
 mv Lib/test_keep Lib/test
 
-# Remove ensurepip stubs.
-rm -rf Lib/ensurepip
-
 if [ $(uname) == Darwin ]; then
   export CFLAGS="-I$PREFIX/include $CFLAGS"
   export LDFLAGS="-Wl,-rpath,$PREFIX/lib -L$PREFIX/lib -headerpad_max_install_names $LDFLAGS"
@@ -29,7 +26,7 @@ fi
 
 ./configure --enable-shared \
             --enable-ipv6 \
-            --with-ensurepip=no \
+            --with-ensurepip=yes \
             --prefix=$PREFIX \
             --with-tcltk-includes="-I$PREFIX/include" \
             --with-tcltk-libs="-L$PREFIX/lib -ltcl8.6 -ltk8.6" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -26,7 +26,7 @@ fi
 
 ./configure --enable-shared \
             --enable-ipv6 \
-            --with-ensurepip=yes \
+            --with-ensurepip=no \
             --prefix=$PREFIX \
             --with-tcltk-includes="-I$PREFIX/include" \
             --with-tcltk-libs="-L$PREFIX/lib -ltcl8.6 -ltk8.6" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
     - winsdk.patch                     # [win]
 
 build:
-  number: 0
+  number: 1
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:


### PR DESCRIPTION
removing ensurepip prevents `python -m venv` from working

matches behavior of defaults channel Python

see https://github.com/ContinuumIO/anaconda-issues/issues/6917 for discussion and https://github.com/AnacondaRecipes/python-feedstock/commit/57adaad35f1a97fe818840f8e1d85007e0d1031a for equivalent change in defaults-channel recipe.