### PR TITLE
Don't -flto-partition=none for toolchain

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -208,7 +208,7 @@ if [[ ${_OPTIMIZED} == yes ]]; then
   _MAKE_TARGET=profile-opt
   # To speed up build times during testing (1):
   # _PROFILE_TASK="./python -m test.regrtest --pgo test_builtin"
-  if [[ ${CC} =~ .*gcc.* ]]; then
+  if [[ ${CC} =~ .*gcc.* && ! ${c_compiler} =~ .*toolchain.* ]]; then
     LTO_CFLAGS+=(-fuse-linker-plugin)
     LTO_CFLAGS+=(-ffat-lto-objects)
     # -flto must come after -flto-partition due to the replacement code

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -135,3 +135,4 @@ extra:
     - msarahan
     - pelson
     - ocefpaf
+    - scopatz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,7 @@ source:
     sha256: de3c87b26a80e789986d8e6950c6304175d3829afe9c6c7211eb7257266ab0ac         # [win]
 
 build:
-  number: 1002
+  number: 1003
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:


### PR DESCRIPTION
 causes downstream compile issues

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
