### PR TITLE
Rebuild with toolchain 2.2.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ environment:
     secure: tumuXLL8PU75WMnRDemRy02ruEq2RpNxeK3dz0MjFssnosPm2v4EFjfNB4PTotA1
 
   matrix:
-    - CONFIG: win_c_compilervs2015cxx_compilervs2015vc14
+    - CONFIG: win_c_compilervs2015cxx_compilervs2015target_platformwin-64vc14
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.ci_support/linux_c_compilergcccxx_compilergxxtarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilergcccxx_compilergxxtarget_platformlinux-64.yaml
@@ -1,17 +1,17 @@
 build_number_decrement:
-- '1000'
+- '0'
 bzip2:
 - '1'
 c_compiler:
-- toolchain_c
+- gcc
 channel_sources:
-- conda-forge,defaults
+- conda-forge/label/gcc7,defaults
 channel_targets:
-- conda-forge main
+- conda-forge gcc7
 cxx_compiler:
-- toolchain_cxx
+- gxx
 docker_image:
-- condaforge/linux-anvil
+- conda/c3i-linux-64
 libffi:
 - '3.2'
 ncurses:
@@ -41,6 +41,8 @@ readline:
 - '7.0'
 sqlite:
 - '3'
+target_platform:
+- linux-64
 tk:
 - '8.6'
 xz:

--- a/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformlinux-64.yaml
+++ b/.ci_support/linux_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformlinux-64.yaml
@@ -1,17 +1,17 @@
 build_number_decrement:
-- '0'
+- '1000'
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- toolchain_c
 channel_sources:
-- conda-forge/label/gcc7,defaults
+- conda-forge,defaults
 channel_targets:
-- conda-forge gcc7
+- conda-forge main
 cxx_compiler:
-- gxx
+- toolchain_cxx
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil
 libffi:
 - '3.2'
 ncurses:
@@ -41,6 +41,8 @@ readline:
 - '7.0'
 sqlite:
 - '3'
+target_platform:
+- linux-64
 tk:
 - '8.6'
 xz:

--- a/.ci_support/osx_c_compilerclangcxx_compilerclangxxtarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilerclangcxx_compilerclangxxtarget_platformosx-64.yaml
@@ -1,17 +1,17 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 build_number_decrement:
-- '1000'
+- '0'
 bzip2:
 - '1'
 c_compiler:
-- toolchain_c
+- clang
 channel_sources:
-- conda-forge,defaults
+- conda-forge/label/gcc7,defaults
 channel_targets:
-- conda-forge main
+- conda-forge gcc7
 cxx_compiler:
-- toolchain_cxx
+- clangxx
 libffi:
 - '3.2'
 macos_machine:
@@ -41,6 +41,8 @@ readline:
 - '7.0'
 sqlite:
 - '3'
+target_platform:
+- osx-64
 tk:
 - '8.6'
 xz:

--- a/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformosx-64.yaml
+++ b/.ci_support/osx_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformosx-64.yaml
@@ -1,17 +1,17 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 build_number_decrement:
-- '0'
+- '1000'
 bzip2:
 - '1'
 c_compiler:
-- clang
+- toolchain_c
 channel_sources:
-- conda-forge/label/gcc7,defaults
+- conda-forge,defaults
 channel_targets:
-- conda-forge gcc7
+- conda-forge main
 cxx_compiler:
-- clangxx
+- toolchain_cxx
 libffi:
 - '3.2'
 macos_machine:
@@ -41,6 +41,8 @@ readline:
 - '7.0'
 sqlite:
 - '3'
+target_platform:
+- osx-64
 tk:
 - '8.6'
 xz:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015target_platformwin-64vc14.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015target_platformwin-64vc14.yaml
@@ -13,6 +13,8 @@ pin_run_as_build:
     max_pin: x
   vc:
     max_pin: x
+target_platform:
+- win-64
 vc:
 - '14'
 zip_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2
 
 jobs:
-  build_linux_c_compilergcccxx_compilergxx:
+  build_linux_c_compilergcccxx_compilergxxtarget_platformlinux-64:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_c_compilergcccxx_compilergxx"
+      - CONFIG: "linux_c_compilergcccxx_compilergxxtarget_platformlinux-64"
     steps:
       - checkout
       - run:
@@ -18,11 +18,11 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh
-  build_linux_c_compilertoolchain_ccxx_compilertoolchain_cxx:
+  build_linux_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformlinux-64:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_c_compilertoolchain_ccxx_compilertoolchain_cxx"
+      - CONFIG: "linux_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformlinux-64"
     steps:
       - checkout
       - run:
@@ -35,12 +35,12 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh
-  build_osx_c_compilerclangcxx_compilerclangxx:
+  build_osx_c_compilerclangcxx_compilerclangxxtarget_platformosx-64:
     working_directory: ~/test
     macos:
       xcode: "9.0"
     environment:
-      - CONFIG: "osx_c_compilerclangcxx_compilerclangxx"
+      - CONFIG: "osx_c_compilerclangcxx_compilerclangxxtarget_platformosx-64"
     steps:
       - checkout
       - run:
@@ -51,12 +51,12 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_osx_build.sh
-  build_osx_c_compilertoolchain_ccxx_compilertoolchain_cxx:
+  build_osx_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformosx-64:
     working_directory: ~/test
     macos:
       xcode: "9.0"
     environment:
-      - CONFIG: "osx_c_compilertoolchain_ccxx_compilertoolchain_cxx"
+      - CONFIG: "osx_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformosx-64"
     steps:
       - checkout
       - run:
@@ -72,7 +72,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_linux_c_compilergcccxx_compilergxx
-      - build_linux_c_compilertoolchain_ccxx_compilertoolchain_cxx
-      - build_osx_c_compilerclangcxx_compilerclangxx
-      - build_osx_c_compilertoolchain_ccxx_compilertoolchain_cxx
+      - build_linux_c_compilergcccxx_compilergxxtarget_platformlinux-64
+      - build_linux_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformlinux-64
+      - build_osx_c_compilerclangcxx_compilerclangxxtarget_platformosx-64
+      - build_osx_c_compilertoolchain_ccxx_compilertoolchain_cxxtarget_platformosx-64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,7 @@ source:
     sha256: de3c87b26a80e789986d8e6950c6304175d3829afe9c6c7211eb7257266ab0ac         # [win]
 
 build:
-  number: 1005
+  number: 1006
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:


### PR DESCRIPTION
There was an issue with the `toolchain`; where, on a newer macOS version, it may not pickup the right SDK. For example, the macOS 10.9 SDK was not being picked up on CircleCI, which runs on a newer version of macOS. Turns out that setting `MACOSX_DEPLOYMENT_TARGET` is not sufficient in these cases and one needs to specify the macOS SDK location as well.

As of `toolchain` 2.2.2, the lazy symbol binding issue has been fixed thanks to the addition of `-isysroot` compiler flag, which specifies the location of the macos SDK we intend to use. Combined with the facts that we specify what minimum macOS version we target and we provide the macOS SDK, this is enough for the build to use that macOS SDK and not pick up these symbols, which do not appear until later macOS versions.

---

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

---

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/python-feedstock/issues/201

<!--
Please add any other relevant info below:
-->

Related to https://github.com/conda-forge/toolchain-feedstock/pull/46