### PR TITLE
ncurse on run

### DIFF
--- a/.ci_support/linux_c_compilergcccxx_compilergxx.yaml
+++ b/.ci_support/linux_c_compilergcccxx_compilergxx.yaml
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 libffi:
 - '3.2'
 ncurses:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -122,6 +122,9 @@ requirements:
     - tk                                 # [unix]
     - ncurses                            # [unix]
     - libffi                             # [unix]
+  run:
+    - ncurses                            # [unix]
+
 
 test:
   commands:


### PR DESCRIPTION
We don't have `run_exports` on `ncurses` yet (working on it), until then let's re-add it to run b/c this is causing problems downstream.

Ping @rsignell-usgs 