### PR TITLE
bump to 3.6.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,12 @@
-{% set version = "3.6.6" %}
-{% set sha256 = "7d56dadf6c7d92a238702389e80cfe66fbfae73e584189ed6f89c75bbf3eda58" %}
+{% set version = "3.6.7" %}
 
 package:
   name: python
   version: {{ version }}
 
 source:
-  - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}.tgz
-    sha256: {{ sha256 }}
+  - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}.tar.xz
+    sha256: 81fd1401a9d66533b0a3e9e3f4ea1c7c6702d57d5b90d659f971e6f1b745f77d
     patches:
       {% if 'toolchain' in compiler('c') %}
       # use one set of patches for the toolchain (old compiler) build
@@ -72,9 +71,9 @@ source:
     folder: externals/sqlite-3.21.0.0                                                # [win]
     sha256: 95a4f2d76aeeb68b51239340e3de26e5714ecfb7c8ad82a67b17af82213a8c20         # [win]
 
-  - url: https://github.com/python/cpython-source-deps/archive/openssl-1.0.2o.zip    # [win]
-    folder: externals/openssl-1.0.2o                                                 # [win]
-    sha256: 9db2a35ef254b57e16a47916810a3bf1cd639b512b5fe6c1cb51afc985113595         # [win]
+  - url: https://github.com/python/cpython-source-deps/archive/openssl-1.0.2p.zip    # [win]
+    folder: externals/openssl-1.0.2p                                                 # [win]
+    sha256: f4b177dbac060bdccc42e08a691ee9e9626ffc3be8aab26002bf0114d3b31aee         # [win]
 #  - url: https://github.com/python/cpython-bin-deps/archive/openssl-bin-1.0.2o.zip   # [win]
 #    folder: externals/openssl-bin-1.0.2o                                             # [win]
 #    sha256: c0e84e40f39b15125a63339f372a62b692ae91f82bf98c9e361b9296ecadcb31         # [win]
@@ -87,7 +86,7 @@ source:
 
 
 build:
-  number: 1003
+  number: 1000
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:


### PR DESCRIPTION
This also changes the `openssl` on Windows to `openssl-1.0.2p`