### PR TITLE
feature request: enable sqlite3 loadable extension support

### DIFF
--- a/recipe/enable-loadable-sqlite-extensions.patch
+++ b/recipe/enable-loadable-sqlite-extensions.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 33cecc6..0b125a1 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1194,7 +1194,7 @@ class PyBuildExt(build_ext):
+                 sqlite_defines.append(('MODULE_NAME', '\\"sqlite3\\"'))
+ 
+             # Comment this out if you want the sqlite3 module to be able to load extensions.
+-            sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))
++            # sqlite_defines.append(("SQLITE_OMIT_LOAD_EXTENSION", "1"))
+ 
+             if host_platform == 'darwin':
+                 # In every directory on the search path search for a dynamic

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ source:
       - 0013-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
       - 0014-Fix-cross-compilation-on-Debian-based-distros.patch
       {% endif %}
+      # use an additional set of patches for any build
+      - enable-loadable-sqlite-extensions.patch
   - url: https://github.com/python/cpython-source-deps/archive/bzip2-1.0.6.zip      # [win]
     folder: externals/bzip2-1.0.6                                                   # [win]
     sha256: c42fd1432a2667b964a74bc423bb7485059c4a6d5dc92946d59dbf9a6bdb988d        # [win]
@@ -63,7 +65,7 @@ source:
 
 
 build:
-  number: 1005
+  number: 1006
   no_link:
     - bin/python2.7     # [unix]
     - DLLs/_ctypes.pyd  # [win]

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -132,3 +132,7 @@ pprint(platform._sys_version())
 
 if int(os.getenv('GUI_TEST', 0)):
     turtle.forward(100)
+
+# did sqlite compile with loadable extension support?
+import sqlite3
+assert hasattr(sqlite3.Connection, 'enable_load_extension')


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)

In response to #97, sqlite3 loadable extension support was enabled for python 3, but not python 2.
According to [the python manual](https://docs.python.org/2/library/sqlite3.html#f1), this is enabled by editing `setup.py`, so I've included a patch to do that.

Though I'm unfamiliar with conda-forge build recipes, [local tests](https://conda-forge.org/docs/testing.html#run-docker-tests-locally-for-feedstock) build as intended in my environment.
While the python 3 recipe seems to lack a feature test in `recipe/run_test.py` (despite it discussed in #97), I've also included one here.
Do we need anything else?