### PR TITLE
fix default _sysconfigdata.py file

### DIFF
--- a/recipe/gcc_build.sh
+++ b/recipe/gcc_build.sh
@@ -149,9 +149,6 @@ popd
 #   using the new compilers with python will require setting _PYTHON_SYSCONFIGDATA_NAME
 #   to the name of this file (minus the .py extension)
 pushd $PREFIX/lib/python${VER}
-  # copy the generated _sysconfigdata.py file for reference latter, this is
-  # never actually used but can be useful for debugging
-  cp _sysconfigdata.py _sysconfigdata_from_initial_build.py
   # On Python 3.5 _sysconfigdata.py was getting copied in here and compiled for some reason.
   # This breaks our attempt to find the right one as recorded_name.
   find lib-dynload -name "_sysconfigdata*.py*" -exec rm {} \;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ source:
 
 
 build:
-  number: 1007
+  number: 1008
   no_link:
     - bin/python2.7     # [unix]
     - DLLs/_ctypes.pyd  # [win]


### PR DESCRIPTION
Creating the _sysconfigdata_from_initial_build.py broke the logic that copied
the default _sysconfigdata.py file from the recipe directory.

closes #248

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
