### PR TITLE
fix default _sysconfigdata.py file

### DIFF
--- a/recipe/gcc_build.sh
+++ b/recipe/gcc_build.sh
@@ -311,9 +311,6 @@ popd
 #   using the new compilers with python will require setting _PYTHON_SYSCONFIGDATA_NAME
 #   to the name of this file (minus the .py extension)
 pushd $PREFIX/lib/python${VER}
-  # copy the generated _sysconfigdata.py file for reference latter, this is
-  # never actually used but can be useful for debugging
-  cp _sysconfigdata*.py _sysconfigdata_from_initial_build.py
   # On Python 3.5 _sysconfigdata.py was getting copied in here and compiled for some reason.
   # This breaks our attempt to find the right one as recorded_name.
   find lib-dynload -name "_sysconfigdata*.py*" -exec rm {} \;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,7 @@ source:
 
 
 build:
-  number: 1003
+  number: 1004
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:


### PR DESCRIPTION
Creating the _sysconfigdata_from_initial_build.py broke the logic that copied
the default _sysconfigdata.py file from the recipe directory.