### PR TITLE
Don't py_compile python2 syntax test files

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,9 +16,7 @@ steps:
     BINSTAR_TOKEN: 
       from_secret: BINSTAR_TOKEN
   commands:
-    - pwd
-    - export FEEDSTOCK_ROOT="${CI_WORKSPACE:-$(pwd)}"
-    - echo "$FEEDSTOCK_ROOT" 
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
     - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
     - export CI=drone
     - export GIT_BRANCH="$DRONE_BRANCH"

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,7 @@ source:
 
 
 build:
-  number: 3
+  number: 4
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:
@@ -78,6 +78,8 @@ build:
   script_env:
     - python_branding
   skip: true  # [win and vc != '14.1']
+  skip_compile_pyc:
+    - lib/python3.*/lib2to3/tests/data/*.py  # [py>=30]
   # We delete the shared libraries.
   ignore_run_exports:   # [unix]
     - bzip2             # [unix]


### PR DESCRIPTION
This PR adds the 2to3 input test files to the `skip_compile_pyc` list. `py_compile` is [currently broken](https://bugs.python.org/issue38731) meaning that if any module can't be compiled, the whole thing dies, so we need to work around that for now (not compiling these test inputs is the right thing to do anyway, IMO).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
--> 