### PR TITLE
backport ranlib patch, require ncurses on osx

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -115,7 +115,9 @@ requirements:
     - make  # [not win]
     - pkg-config  # [not win]
     # configure script looks for llvm-ar for lto
+{% if 'conda-forge' in channel_targets %}
     - llvm-tools  # [osx]
+{% endif %}
     - patch  # [not win]
     - m2-patch  # [win]
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ source:
 {% if 'conda-forge' not in channel_targets %}
       - patches/0019-Add-CondaEcosystemModifyDllSearchPath.patch
 {% endif %}
+      - patches/0020-Use-ranlib-from-env-if-env-variable-is-set.patch
   # TODO :: Depend on our own packages for these:
   - url: https://github.com/python/cpython-source-deps/archive/xz-5.2.2.zip          # [win]
     folder: externals/xz-5.2.2                                                       # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,7 @@ source:
     sha256: de3c87b26a80e789986d8e6950c6304175d3829afe9c6c7211eb7257266ab0ac         # [win]
 
 build:
-  number: 1
+  number: 2
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -128,7 +128,7 @@ requirements:
     - openssl
     - readline  # [not win]
     - tk  # [not win]
-    - ncurses  # [linux]
+    - ncurses  # [not win]
     - libffi  # [not win]
     - binutils_impl_{{target_platform}}  # [aarch64]
     - ld_impl_{{target_platform}}  # [linux and not aarch64]

--- a/recipe/patches/0020-Use-ranlib-from-env-if-env-variable-is-set.patch
+++ b/recipe/patches/0020-Use-ranlib-from-env-if-env-variable-is-set.patch
@@ -1,0 +1,26 @@
+From 67b9aaeb96e0ad7e4f493293145f0dba5177fc4d Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Sun, 3 Nov 2019 15:09:45 -0600
+Subject: [PATCH 20/22] Use ranlib from env if env variable is set
+
+---
+ Lib/distutils/sysconfig.py | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Lib/distutils/sysconfig.py b/Lib/distutils/sysconfig.py
+index 849f98f929..ab9b195756 100644
+--- a/Lib/distutils/sysconfig.py
++++ b/Lib/distutils/sysconfig.py
+@@ -234,6 +234,9 @@ def customize_compiler(compiler):
+             linker_exe=cc,
+             archiver=archiver)
+ 
++        if 'RANLIB' in os.environ and 'ranlib' in compiler.executables:
++            compiler.set_executables(ranlib=os.environ['RANLIB'])
++
+         compiler.shared_lib_extension = shlib_suffix
+ 
+ 
+-- 
+2.24.0
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
