### PR TITLE
REF remove extra base_version key to allow bot to update python

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -73,4 +73,4 @@ jobs:
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -100,4 +100,4 @@ jobs:
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-      condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/linux_aarch64_target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_target_platformlinux-aarch64.yaml
@@ -11,7 +11,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge,c4aarch64,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
@@ -25,7 +25,7 @@ libffi:
 ncurses:
 - '6.1'
 openssl:
-- 1.1.1a
+- 1.1.1
 pin_run_as_build:
   bzip2:
     max_pin: x

--- a/.ci_support/linux_ppc64le_target_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_target_platformlinux-ppc64le.yaml
@@ -19,7 +19,7 @@ libffi:
 ncurses:
 - '6.1'
 openssl:
-- 1.1.1a
+- 1.1.1
 pin_run_as_build:
   bzip2:
     max_pin: x

--- a/.ci_support/linux_target_platformlinux-64.yaml
+++ b/.ci_support/linux_target_platformlinux-64.yaml
@@ -19,7 +19,7 @@ libffi:
 ncurses:
 - '6.1'
 openssl:
-- 1.1.1a
+- 1.1.1
 pin_run_as_build:
   bzip2:
     max_pin: x

--- a/.ci_support/osx_target_platformosx-64.yaml
+++ b/.ci_support/osx_target_platformosx-64.yaml
@@ -21,7 +21,7 @@ macos_machine:
 macos_min_version:
 - '10.9'
 openssl:
-- 1.1.1a
+- 1.1.1
 pin_run_as_build:
   bzip2:
     max_pin: x

--- a/.ci_support/win_target_platformwin-64.yaml
+++ b/.ci_support/win_target_platformwin-64.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - vs2017
 openssl:
-- 1.1.1a
+- 1.1.1
 pin_run_as_build:
   openssl:
     max_pin: x.x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,8 +100,6 @@ build:
   skip: True            # [win and int(float(vc)) < 14]
 # Would like to be able to append to the calculated build string here, ping @msarahan, is this possible?
   string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}{{ linkage_nature }}{{ debug }}_cpython
-  run_exports:
-   - python_abi 3.8.* cp38
   script_env:
    - PY_INTERP_LINKAGE_NATURE
    - PY_INTERP_DEBUG

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
-{% set base_version = "3.8.1" %}
-{% set version = base_version %}
+{% set version = "3.8.1" %}
 {% set linkage_nature = os.environ.get('PY_INTERP_LINKAGE_NATURE', '') %}
 {% set debug = os.environ.get('PY_INTERP_DEBUG', '') %}
 {% if linkage_nature != '' %}
@@ -11,10 +10,10 @@
 
 package:
   name: python
-  version: {{ base_version }}
+  version: {{ version }}
 
 source:
-  - url: https://www.python.org/ftp/python/{{ base_version }}/Python-{{ version }}.tar.xz
+  - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-381/
     md5: b3fb85fd479c0bf950c626ef80cacb57
     patches:
@@ -78,7 +77,7 @@ source:
 
 
 build:
-  number: 3
+  number: 4
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This change will allow the auto-tick bot to push version updates I think. 