### PR TITLE
Add `python_abi` to `run_constrained` (for 3.6)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -125,6 +125,8 @@ requirements:
   run:
     - ncurses                            # [unix]
     - ld_impl_{{ target_platform }}      # [linux]
+  run_constrained:
+    - python_abi 3.6.* *_cp36m
 
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,7 @@ source:
 
 
 build:
-  number: 1008
+  number: 1009
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.6.7" %}
+{% set version = "3.6.10" %}
 
 package:
   name: python
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}.tar.xz
-    sha256: 81fd1401a9d66533b0a3e9e3f4ea1c7c6702d57d5b90d659f971e6f1b745f77d
+    sha256: 0a833c398ac8cd7c5538f7232d8531afef943c60495c504484f308dac3af40de
     patches:
       {% if 'toolchain' in compiler('c') %}
       # use one set of patches for the toolchain (old compiler) build
@@ -82,7 +82,7 @@ source:
 
 
 build:
-  number: 1009
+  number: 0
   # Windows has issues updating python if conda is using files itself.
   # Copy rather than link.
   no_link:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
