### PR TITLE
Add `python_abi` to `run_constrained` (for 2.7)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ source:
 
 
 build:
-  number: 1010
+  number: 1011
   no_link:
     - bin/python2.7     # [unix]
     - DLLs/_ctypes.pyd  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -104,6 +104,9 @@ requirements:
     - ld_impl_{{ target_platform }}      # [linux]
   run:
     - ld_impl_{{ target_platform }}      # [linux]
+  run_constrained:
+    - python_abi 2.7.* *_cp27m           # [not linux]
+    - python_abi 2.7.* *_cp27mu          # [linux]
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
