### PR TITLE
Fix off-by-one on Windows, sync patch from Anaconda

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ source:
     # md5 from: https://www.python.org/downloads/release/python-385/
     md5: 35b5a3d0254c1c59be9736373d429db7
     patches:
+      - patches/0000-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch
 {% if 'conda-forge' not in channel_targets %}
       - patches/0001-Add-Anaconda-Distribution-version-logic.patch
 {% endif %}
@@ -82,7 +83,7 @@ source:
     sha256: 4872e72e188a5aa1124db0c3b163a4163e84ead359a514d86dd7c6fa2d2ff02a         # [win]
 
 build:
-  number: 8
+  number: 9
   script_env:
     - PY_INTERP_LINKAGE_NATURE
     - PY_INTERP_DEBUG

--- a/recipe/patches/0000-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch
+++ b/recipe/patches/0000-Fix-off-by-one-error-in-_winapi_WaitForMultipleObjec.patch
@@ -1,0 +1,26 @@
+From 48755cdaaeb7e4ab82d1b96cc80c0ab67a0c7b0d Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
+Date: Sun, 12 Apr 2020 18:22:21 +0200
+Subject: [PATCH 00/26] Fix off-by-one-error in
+ _winapi_WaitForMultipleObjects_impl
+
+---
+ Modules/_winapi.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Modules/_winapi.c b/Modules/_winapi.c
+index 647075cdb1..aec836ad82 100644
+--- a/Modules/_winapi.c
++++ b/Modules/_winapi.c
+@@ -1706,7 +1706,7 @@ _winapi_WaitForMultipleObjects_impl(PyObject *module, PyObject *handle_seq,
+     nhandles = PySequence_Length(handle_seq);
+     if (nhandles == -1)
+         return NULL;
+-    if (nhandles < 0 || nhandles >= MAXIMUM_WAIT_OBJECTS - 1) {
++    if (nhandles < 0 || nhandles > MAXIMUM_WAIT_OBJECTS - 1) {
+         PyErr_Format(PyExc_ValueError,
+                      "need at most %zd handles, got a sequence of length %zd",
+                      MAXIMUM_WAIT_OBJECTS - 1, nhandles);
+-- 
+2.24.3 (Apple Git-128)
+


### PR DESCRIPTION
I looked through the patches @mingwandroid mentioned in https://github.com/conda-forge/python-feedstock/pull/389#issuecomment-695186852 and realized that this probably is the fix for the black issues one of my colleagues is seeing in https://github.com/psf/black/issues/564

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
