### PR TITLE
 Add patch for https://bugs.python.org/issue42015 (which affects pybind11)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,7 +12,6 @@ jobs:
         CONFIG: linux_64_target_platformlinux-64
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -14,7 +14,6 @@ jobs:
       osx_arm64_target_platformosx-arm64:
         CONFIG: osx_arm64_target_platformosx-arm64
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,7 +11,6 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 4
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
@@ -53,7 +52,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
+        packageSpecs: 'python=3.6 conda-build conda "conda-forge-ci-setup=3" pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment

--- a/.ci_support/linux_64_target_platformlinux-64.yaml
+++ b/.ci_support/linux_64_target_platformlinux-64.yaml
@@ -43,7 +43,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.8'
+- '3.9'
 readline:
 - '8.0'
 sqlite:
@@ -54,5 +54,8 @@ tk:
 - '8.6'
 xz:
 - '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/linux_aarch64_target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_target_platformlinux-aarch64.yaml
@@ -5,7 +5,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.5'
+- '7'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.5'
+- '7'
 docker_image:
 - condaforge/linux-anvil-aarch64
 libffi:
@@ -49,7 +49,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.8'
+- '3.9'
 readline:
 - '8.0'
 sqlite:
@@ -60,5 +60,8 @@ tk:
 - '8.6'
 xz:
 - '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/linux_ppc64le_target_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_target_platformlinux-ppc64le.yaml
@@ -41,7 +41,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.8'
+- '3.9'
 readline:
 - '8.0'
 sqlite:
@@ -50,5 +50,8 @@ target_platform:
 - linux-ppc64le
 xz:
 - '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/osx_64_target_platformosx-64.yaml
+++ b/.ci_support/osx_64_target_platformosx-64.yaml
@@ -45,7 +45,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.8'
+- '3.9'
 readline:
 - '8.0'
 sqlite:
@@ -56,5 +56,8 @@ tk:
 - '8.6'
 xz:
 - '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/osx_arm64_target_platformosx-arm64.yaml
+++ b/.ci_support/osx_arm64_target_platformosx-arm64.yaml
@@ -45,7 +45,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '3.8'
+- '3.9'
 readline:
 - '8.0'
 sqlite:
@@ -56,5 +56,8 @@ tk:
 - '8.6'
 xz:
 - '5.2'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 zlib:
 - '1.2'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -17,7 +17,7 @@ pin_run_as_build:
   sqlite:
     max_pin: x
 python:
-- '3.8'
+- '3.9'
 sqlite:
 - '3'
 target_platform:

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 *.diff binary
 meta.yaml text eol=lf
 build.sh text eol=lf
-recipe/tests/prefix-replacement/build-and-test.sh text eof=lf
 bld.bat text eol=crlf
 
 # github helper pieces to make some files not show up in diffs automatically

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @isuruf @jakirkham @jjhelmus @mingwandroid @msarahan @ocefpaf @pelson @scopatz
+* @isuruf @jakirkham @jjhelmus @mbargull @mingwandroid @msarahan @ocefpaf @pelson @scopatz

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,7 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -41,13 +41,25 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
      EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 
-conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-    --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
-if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
+    fi
+    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    # Drop into an interactive shell
+    /bin/bash
+else
+    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    validate_recipe_outputs "${FEEDSTOCK_NAME}"
+
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+        upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    fi
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,7 +23,7 @@ source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip
 
 
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ Home: https://www.python.org/
 
 Package license: Python-2.0
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/python-feedstock/blob/master/LICENSE.txt)
 
 Summary: General purpose programming language
+
+Development: https://docs.python.org/devguide/
+
+Documentation: https://www.python.org/doc/versions/
 
 Python is a widely used high-level, general-purpose, interpreted, dynamic
 programming language. Its design philosophy emphasizes code

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Feedstock Maintainers
 * [@isuruf](https://github.com/isuruf/)
 * [@jakirkham](https://github.com/jakirkham/)
 * [@jjhelmus](https://github.com/jjhelmus/)
+* [@mbargull](https://github.com/mbargull/)
 * [@mingwandroid](https://github.com/mingwandroid/)
 * [@msarahan](https://github.com/msarahan/)
 * [@ocefpaf](https://github.com/ocefpaf/)

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -16,13 +16,14 @@ if "%ARCH%"=="64" (
    set BUILD_PATH=win32
 )
 
+:: Make sure PKG_VERSION and PY_VER are in agreement.
 for /F "tokens=1,2 delims=." %%i in ("%PKG_VERSION%") do (
-  :: Make sure PKG_VERSION and PY_VER are in agreement.
   if NOT "%PY_VER%"=="%%i%%j" exit 1
-  :: PY_VER is set due to "python" being in conda_build_config.yaml.
-  :: If we are going to change it, we need to set it manually via the line below:
-  :: set "PY_VER=:%i%%j"
 )
+:: PY_VER is set due to "python" being in conda_build_config.yaml.
+:: If we are going to change it, we need to set it manually by replacing the
+:: test `IF NOT ""%PY_VER%"==...` line above with the one below:
+:: set "PY_VER=:%i%%j"
 
 set "OPENSSL_DIR=%LIBRARY_PREFIX%"
 set "SQLITE3_DIR=%LIBRARY_PREFIX%"

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -16,7 +16,7 @@ if "%ARCH%"=="64" (
    set BUILD_PATH=win32
 )
 
-for /F "token=1,2 delims=." %%i in ("%PKG_VERSION%") do (
+for /F "tokens=1,2 delims=." %%i in ("%PKG_VERSION%") do (
   :: Make sure PKG_VERSION and PY_VER are in agreement.
   if NOT "%PY_VER%"=="%%i%%j" exit 1
   :: PY_VER is set due to "python" being in conda_build_config.yaml.

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -16,14 +16,14 @@ if "%ARCH%"=="64" (
    set BUILD_PATH=win32
 )
 
-:: Make sure PKG_VERSION and PY_VER are in agreement.
 for /F "tokens=1,2 delims=." %%i in ("%PKG_VERSION%") do (
-  if NOT "%PY_VER%"=="%%i%%j" exit 1
+  set "VERNODOTS=:%%i%%j"
 )
-:: PY_VER is set due to "python" being in conda_build_config.yaml.
-:: If we are going to change it, we need to set it manually by replacing the
-:: test `IF NOT ""%PY_VER%"==...` line above with the one below:
-:: set "PY_VER=:%i%%j"
+
+::  Make sure the "python" value in conda_build_config.yaml is up to date.
+for /F "tokens=1,2 delims=." %%i in ("%PKG_VERSION%") do (
+  if NOT "%PY_VER%"=="%%i.%%j" exit 1
+)
 
 set "OPENSSL_DIR=%LIBRARY_PREFIX%"
 set "SQLITE3_DIR=%LIBRARY_PREFIX%"
@@ -59,7 +59,7 @@ if errorlevel 1 exit 1
 cd ..
 
 :: Populate the root package directory
-for %%x in (python%PY_VER%%_D%.dll python3%_D%.dll python%_D%.exe pythonw%_D%.exe venvlauncher%_D%.exe venvwlauncher%_D%.exe) do (
+for %%x in (python%VERNODOTS%%_D%.dll python3%_D%.dll python%_D%.exe pythonw%_D%.exe venvlauncher%_D%.exe venvwlauncher%_D%.exe) do (
   if exist %SRC_DIR%\PCbuild\%BUILD_PATH%\%%x (
     copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\%%x %PREFIX%
   ) else (
@@ -67,7 +67,7 @@ for %%x in (python%PY_VER%%_D%.dll python3%_D%.dll python%_D%.exe pythonw%_D%.ex
   )
 )
 
-for %%x in (python%_D%.pdb python%PY_VER%%_D%.pdb pythonw%_D%.pdb) do (
+for %%x in (python%_D%.pdb python%VERNODOTS%%_D%.pdb pythonw%_D%.pdb) do (
   if exist %SRC_DIR%\PCbuild\%BUILD_PATH%\%%x (
     copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\%%x %PREFIX%
   ) else (
@@ -149,7 +149,7 @@ if errorlevel 1 exit 1
 
 :: Populate the libs directory
 if not exist %PREFIX%\libs mkdir %PREFIX%\libs
-if exist %SRC_DIR%\PCbuild\%BUILD_PATH%\python%PY_VER%%_D%.lib copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\python%PY_VER%%_D%.lib %PREFIX%\libs\
+if exist %SRC_DIR%\PCbuild\%BUILD_PATH%\python%VERNODOTS%%_D%.lib copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\python%VERNODOTS%%_D%.lib %PREFIX%\libs\
 if errorlevel 1 exit 1
 if exist %SRC_DIR%\PCbuild\%BUILD_PATH%\python3%_D%.lib copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\python3%_D%.lib %PREFIX%\libs\
 if errorlevel 1 exit 1

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -17,7 +17,7 @@ if "%ARCH%"=="64" (
 )
 
 for /F "tokens=1,2 delims=." %%i in ("%PKG_VERSION%") do (
-  set "VERNODOTS=:%%i%%j"
+  set "VERNODOTS=%%i%%j"
 )
 
 ::  Make sure the "python" value in conda_build_config.yaml is up to date.

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -16,7 +16,13 @@ if "%ARCH%"=="64" (
    set BUILD_PATH=win32
 )
 
-set PY_VER=39
+for /F "token=1,2 delims=." %%i in ("%PKG_VERSION%") do (
+  :: Make sure PKG_VERSION and PY_VER are in agreement.
+  if NOT "%PY_VER%"=="%%i%%j" exit 1
+  :: PY_VER is set due to "python" being in conda_build_config.yaml.
+  :: If we are going to change it, we need to set it manually via the line below:
+  :: set "PY_VER=:%i%%j"
+)
 
 set "OPENSSL_DIR=%LIBRARY_PREFIX%"
 set "SQLITE3_DIR=%LIBRARY_PREFIX%"

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -60,6 +60,9 @@ fi
 ABIFLAGS=${DBG}
 VERABI=${VER}${DBG}
 
+# Make sure the "python" value in conda_build_config.yaml is up to date.
+test "${PY_VER}" = "${VER}"
+
 # This is the mechanism by which we fall back to default gcc, but having it defined here
 # would probably break the build by using incorrect settings and/or importing files that
 # do not yet exist.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,5 @@
 python:
   - 3.9
-python_impl:
-  - cpython
-numpy:
-  - 1.19
 c_compiler:                    # [win]
   - vs2017                     # [win]
 cxx_compiler:                  # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 python:
-  - 3.8
+  - 3.9
 c_compiler:                    # [win]
   - vs2017                     # [win]
 cxx_compiler:                  # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,9 @@
 python:
   - 3.9
+python_impl:
+  - cpython
+numpy:
+  - 1.19
 c_compiler:                    # [win]
   - vs2017                     # [win]
 cxx_compiler:                  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -348,9 +348,9 @@ extra:
     - isuruf
     - jakirkham
     - jjhelmus
+    - mbargull
     - mingwandroid
     - msarahan
     - pelson
     - ocefpaf
     - scopatz
-    - mbargull

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,6 +80,7 @@ source:
       - patches/0030-gh21564.patch
       - patches/0031-gh21228.patch
       - patches/0032-Fix-TZPATH-on-windows.patch
+      - patches/0033-gh22674.patch
 
   # TODO :: Depend on our own packages for these:
   - url: https://github.com/python/cpython-source-deps/archive/xz-5.2.2.zip          # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 3 %}
+{% set build_number = 4 %}
 
 # Sanitize build system env. var tweak parameters
 # (passed to the build scripts via script_env).

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -353,3 +353,4 @@ extra:
     - pelson
     - ocefpaf
     - scopatz
+    - mbargull

--- a/recipe/patches/0033-gh22674.patch
+++ b/recipe/patches/0033-gh22674.patch
@@ -1,0 +1,51 @@
+From c2fe794b81af88b232fddaefaa7460d444941548 Mon Sep 17 00:00:00 2001
+From: Yannick Jadoul <yannick.jadoul@belgacom.net>
+Date: Mon, 12 Oct 2020 23:06:19 +0200
+Subject: [PATCH] bpo-42015: Reorder dereferencing calls in meth_dealloc, to
+ make sure m_self is kept alive long enough (GH-22670) (cherry picked from
+ commit 04b8631d84a870dda456ef86039c1baf34d08500)
+
+Co-authored-by: Yannick Jadoul <yannick.jadoul@belgacom.net>
+---
+ .../next/C API/2020-10-12-20-13-58.bpo-42015.X4H2_V.rst     | 3 +++
+ Objects/methodobject.c                                      | 6 ++++--
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/C API/2020-10-12-20-13-58.bpo-42015.X4H2_V.rst
+
+diff --git a/Misc/NEWS.d/next/C API/2020-10-12-20-13-58.bpo-42015.X4H2_V.rst b/Misc/NEWS.d/next/C API/2020-10-12-20-13-58.bpo-42015.X4H2_V.rst
+new file mode 100644
+index 0000000000000..d77619f64bb17
+--- /dev/null
++++ b/Misc/NEWS.d/next/C API/2020-10-12-20-13-58.bpo-42015.X4H2_V.rst	
+@@ -0,0 +1,3 @@
++Fix potential crash in deallocating method objects when dynamically
++allocated `PyMethodDef`'s lifetime is managed through the ``self``
++argument of a `PyCFunction`.
+diff --git a/Objects/methodobject.c b/Objects/methodobject.c
+index 5659f2143d182..7b430416c5a04 100644
+--- a/Objects/methodobject.c
++++ b/Objects/methodobject.c
+@@ -164,9 +164,11 @@ meth_dealloc(PyCFunctionObject *m)
+     if (m->m_weakreflist != NULL) {
+         PyObject_ClearWeakRefs((PyObject*) m);
+     }
++    // Dereference class before m_self: PyCFunction_GET_CLASS accesses
++    // PyMethodDef m_ml, which could be kept alive by m_self
++    Py_XDECREF(PyCFunction_GET_CLASS(m));
+     Py_XDECREF(m->m_self);
+     Py_XDECREF(m->m_module);
+-    Py_XDECREF(PyCFunction_GET_CLASS(m));
+     PyObject_GC_Del(m);
+ }
+ 
+@@ -243,9 +245,9 @@ meth_get__qualname__(PyCFunctionObject *m, void *closure)
+ static int
+ meth_traverse(PyCFunctionObject *m, visitproc visit, void *arg)
+ {
++    Py_VISIT(PyCFunction_GET_CLASS(m));
+     Py_VISIT(m->m_self);
+     Py_VISIT(m->m_module);
+-    Py_VISIT(PyCFunction_GET_CLASS(m));
+     return 0;
+ }
+ 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This adds https://github.com/python/cpython/pull/22674 which is a backport of https://github.com/python/cpython/pull/22670 addressing https://bugs.python.org/issue42015 which was reported by the `pybind11` maintainer @YannickJadoul in reference to https://github.com/pybind/pybind11/issues/2558 and their workaround PR https://github.com/pybind/pybind11/pull/2576.

Given the small changeset and scope of the patch, it could make sense to include it in our `python` build even before the Python 3.9.1 release (schedules for December).

cc @isuruf, @conda-forge/pybind11, @henryiii