### PR TITLE
Fix distutils ldshared overriding when a compiler is set in environ

### DIFF
--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -466,7 +466,7 @@ pushd "${PREFIX}"/lib/python${VER}
   sed -i.bak "s@$OLD_HOST-@@g" sysconfigfile
   if [[ "$target_platform" == linux* ]]; then
     # For linux, make sure the system gcc uses our linker
-    sed -i.bak "s@-pthread@-pthread -B $PREFIX/compiler_compat -Wl,--sysroot=/@g" sysconfigfile
+    sed -i.bak "s@-pthread@-pthread -B $PREFIX/compiler_compat@g" sysconfigfile
   fi
   # Don't set -march and -mtune for system gcc
   sed -i.bak "s@-march=[a-z0-9]*@@g" sysconfigfile

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}
@@ -78,6 +78,7 @@ source:
       - patches/0025-cross-compile-darwin.patch
       - patches/0032-Fix-TZPATH-on-windows.patch
       - patches/0033-gh24324.patch
+      - patches/0034-distutils-fix-ldshared.patch
 
   # TODO :: Depend on our own packages for these:
   - url: https://github.com/python/cpython-source-deps/archive/xz-5.2.2.zip  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -208,9 +208,9 @@ outputs:
         - tk  # [not win]
         - ncurses  # [unix]
         - libffi   # [not (win or (osx and arm64))]
-        - ld_impl_{{ target_platform }}  # [linux]
+        - ld_impl_{{ target_platform }} >=2.36.1  # [linux]
       run:
-        - ld_impl_{{ target_platform }}  # [linux]
+        - ld_impl_{{ target_platform }} >=2.36.1  # [linux]
         - tzdata
 {% if 'conda-forge' in channel_targets %}
         - ncurses  # [unix]

--- a/recipe/patches/0034-distutils-fix-ldshared.patch
+++ b/recipe/patches/0034-distutils-fix-ldshared.patch
@@ -1,0 +1,17 @@
+diff --git a/Lib/distutils/sysconfig.py b/Lib/distutils/sysconfig.py
+index 37feae5df7..47cb61854f 100644
+--- a/Lib/distutils/sysconfig.py
++++ b/Lib/distutils/sysconfig.py
+@@ -199,10 +199,9 @@ def customize_compiler(compiler):
+ 
+         if 'CC' in os.environ:
+             newcc = os.environ['CC']
+-            if (sys.platform == 'darwin'
+-                    and 'LDSHARED' not in os.environ
++            if ('LDSHARED' not in os.environ
+                     and ldshared.startswith(cc)):
+-                # On OS X, if CC is overridden, use that as the default
++                # If CC is overridden, use that as the default
+                 #       command for LDSHARED as well
+                 ldshared = newcc + ldshared[len(cc):]
+             cc = newcc


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
