### PR TITLE
create manual new python build against libffi=3.3

### DIFF
--- a/.ci_support/linux_64_openssl1.1.1.yaml
+++ b/.ci_support/linux_64_openssl1.1.1.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 libffi:
-- '3.4'
+- '3.3'
 libuuid:
 - '2'
 ncurses:

--- a/.ci_support/linux_64_openssl3.yaml
+++ b/.ci_support/linux_64_openssl3.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 libffi:
-- '3.4'
+- '3.3'
 libuuid:
 - '2'
 ncurses:

--- a/.ci_support/linux_aarch64_openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_openssl1.1.1.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 libffi:
-- '3.4'
+- '3.3'
 libuuid:
 - '2'
 ncurses:

--- a/.ci_support/linux_aarch64_openssl3.yaml
+++ b/.ci_support/linux_aarch64_openssl3.yaml
@@ -21,7 +21,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 libffi:
-- '3.4'
+- '3.3'
 libuuid:
 - '2'
 ncurses:

--- a/.ci_support/linux_ppc64le_openssl1.1.1.yaml
+++ b/.ci_support/linux_ppc64le_openssl1.1.1.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 libffi:
-- '3.4'
+- '3.3'
 libuuid:
 - '2'
 ncurses:

--- a/.ci_support/linux_ppc64le_openssl3.yaml
+++ b/.ci_support/linux_ppc64le_openssl3.yaml
@@ -17,7 +17,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 libffi:
-- '3.4'
+- '3.3'
 libuuid:
 - '2'
 ncurses:

--- a/.ci_support/osx_64_openssl1.1.1.yaml
+++ b/.ci_support/osx_64_openssl1.1.1.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 libffi:
-- '3.4'
+- '3.3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 ncurses:

--- a/.ci_support/osx_64_openssl3.yaml
+++ b/.ci_support/osx_64_openssl3.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 libffi:
-- '3.4'
+- '3.3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 ncurses:

--- a/.ci_support/osx_arm64_openssl1.1.1.yaml
+++ b/.ci_support/osx_arm64_openssl1.1.1.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 libffi:
-- '3.4'
+- '3.3'
 macos_machine:
 - arm64-apple-darwin20.0.0
 ncurses:

--- a/.ci_support/osx_arm64_openssl3.yaml
+++ b/.ci_support/osx_arm64_openssl3.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 libffi:
-- '3.4'
+- '3.3'
 macos_machine:
 - arm64-apple-darwin20.0.0
 ncurses:

--- a/.ci_support/win_64_openssl1.1.1.yaml
+++ b/.ci_support/win_64_openssl1.1.1.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2017
 libffi:
-- '3.4'
+- '3.3'
 openssl:
 - 1.1.1
 pin_run_as_build:

--- a/.ci_support/win_64_openssl3.yaml
+++ b/.ci_support/win_64_openssl3.yaml
@@ -9,7 +9,7 @@ channel_targets:
 cxx_compiler:
 - vs2017
 libffi:
-- '3.4'
+- '3.3'
 openssl:
 - '3'
 pin_run_as_build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -258,6 +258,8 @@ outputs:
         # Test workaround for https://github.com/conda/conda/issues/10969
         - test -d "$PREFIX/lib/python3.1/site-packages"  # [unix]
         - python3.1 --version  # [unix]
+        # Test for segfault on osx-64 with libffi=3.4, see https://bugs.python.org/issue44556
+        - python -c "from ctypes import CFUNCTYPE; CFUNCTYPE(None)(id)"
 
   - name: libpython-static
     script: build_static.sh  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 2 %}
+{% set build_number = 3 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This is perhaps a lame attempt at creating a python3.10 + libffi build combination that other packages could pin against to avoid bugs perhaps with the libffi=3.4 package.  ie #522 

Totally feel free to reject this forcibly, just attempt to be helpful :)

I purposefully did not re-render.