### PR TITLE
Use python3x.dll path to get the relative directory

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}

--- a/recipe/patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
+++ b/recipe/patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
@@ -1,4 +1,4 @@
-From 58b8a8fc57ec47f4cf8e86b5115ae1da433e19e4 Mon Sep 17 00:00:00 2001
+From 5636f26e0f3dbd4d32889f020d475360a41772fb Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:53:55 +0100
 Subject: [PATCH 01/26] Win32: Change FD_SETSIZE from 512 to 2048
@@ -22,5 +22,5 @@ index 3ecd0c32b3..000d1d8bb2 100644
  
  #if defined(HAVE_POLL_H)
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0002-Win32-distutils-Add-support-to-cygwinccompiler-for-V.patch
+++ b/recipe/patches/0002-Win32-distutils-Add-support-to-cygwinccompiler-for-V.patch
@@ -1,4 +1,4 @@
-From cbdd6fab754212c2bfb3040a94b4b5666e0b5f87 Mon Sep 17 00:00:00 2001
+From 194424e9c0b5b93ee37c1428472f8e970fec8951 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:59:00 +0100
 Subject: [PATCH 02/26] Win32: distutils: Add support to cygwinccompiler for
@@ -24,5 +24,5 @@ index 66c12dd358..e6c790118b 100644
              raise ValueError("Unknown MS Compiler version %s " % msc_ver)
  
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0003-Support-cross-compiling-byte-code.patch
+++ b/recipe/patches/0003-Support-cross-compiling-byte-code.patch
@@ -1,4 +1,4 @@
-From 0012bdf09671fe8b9989e80985e374f27313f9c8 Mon Sep 17 00:00:00 2001
+From 01c5e09cc8d37886834e00f97b541e08b9eaad2d Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 12:17:33 +0100
 Subject: [PATCH 03/26] Support cross-compiling byte-code
@@ -120,5 +120,5 @@ index 5aa91cbad3..86925d9166 100644
  
  dnl Ensure that if prefix is specified, it does not end in a slash. If
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0004-bpo-45258-search-for-isysroot-in-addition-to-sysroot.patch
+++ b/recipe/patches/0004-bpo-45258-search-for-isysroot-in-addition-to-sysroot.patch
@@ -1,4 +1,4 @@
-From 2e661c1c00398f5f7c1aa009deb45a742e8bf708 Mon Sep 17 00:00:00 2001
+From e2bcc5be75347b123be38cf937257dc141e4767c Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Tue, 21 Sep 2021 13:05:20 -0500
 Subject: [PATCH 04/26] bpo-45258: search for -isysroot in addition to
@@ -23,5 +23,5 @@ index 43e807f20d..554699608d 100644
                  sysroot = m.group(1).strip('"')
                  for subdir in subdirs:
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0005-runtime_library_dir_option-Use-1st-word-of-CC-as-com.patch
+++ b/recipe/patches/0005-runtime_library_dir_option-Use-1st-word-of-CC-as-com.patch
@@ -1,4 +1,4 @@
-From 1495f849b09018c7f34b99e16f377ce4b2b645ee Mon Sep 17 00:00:00 2001
+From cb19020286ac0e1edda909d3eb5d1bd8ab7d310c Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Thu, 5 Oct 2017 02:00:41 +0100
 Subject: [PATCH 05/26] runtime_library_dir_option: Use 1st word of CC as
@@ -26,5 +26,5 @@ index d00c48981e..54dd556fe5 100644
              # MacOSX's linker doesn't understand the -R flag at all
              return "-L" + dir
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0006-Win32-Do-not-download-externals.patch
+++ b/recipe/patches/0006-Win32-Do-not-download-externals.patch
@@ -1,4 +1,4 @@
-From 85d70f3973cbb8dc8fd516c6175fb859eafb90ee Mon Sep 17 00:00:00 2001
+From c7ea2f0cc7b07f3335e9a69823117f9a159314e0 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Thu, 7 Sep 2017 11:35:47 +0100
 Subject: [PATCH 06/26] Win32: Do not download externals
@@ -21,5 +21,5 @@ index d333ceabd2..11e3d16a4f 100644
  if "%do_pgo%" EQU "true" if "%platf%" EQU "x64" (
      if "%PROCESSOR_ARCHITEW6432%" NEQ "AMD64" if "%PROCESSOR_ARCHITECTURE%" NEQ "AMD64" (
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0007-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
+++ b/recipe/patches/0007-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -1,4 +1,4 @@
-From 092a7ed67d1af7f7cc88d416e60bad902724022e Mon Sep 17 00:00:00 2001
+From f120f80b8c35ce5f3f852596ffc197525bd68f81 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 5 Dec 2017 22:47:59 +0000
 Subject: [PATCH 07/26] Fix find_library so that it looks in sys.prefix/lib
@@ -72,5 +72,5 @@ index 0c2510e161..72b46cc481 100644
  ################################################################
  # test code
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0008-bpo-22699-Allow-compiling-on-debian-ubuntu-with-a-di.patch
+++ b/recipe/patches/0008-bpo-22699-Allow-compiling-on-debian-ubuntu-with-a-di.patch
@@ -1,4 +1,4 @@
-From 9626b78f45f4ee0057b602f94c8f46b73a2d7c2b Mon Sep 17 00:00:00 2001
+From d1b6287ba2337bff87e662be4ac5e47b1c55ecd5 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Thu, 16 Sep 2021 15:46:09 -0500
 Subject: [PATCH 08/26] bpo-22699: Allow compiling on debian/ubuntu with a
@@ -48,5 +48,5 @@ index 554699608d..d5bbeb90d5 100644
              '%s -print-multiarch > %s 2> /dev/null' % (CC, tmpfile))
          multiarch_path_component = ''
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0009-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
+++ b/recipe/patches/0009-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
@@ -1,4 +1,4 @@
-From 12b9c49e25da55e3f2f5314f6084a3f5c70d4ff0 Mon Sep 17 00:00:00 2001
+From c527da58a6fd6f51427e7de3f81a2970b1d7cb88 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sat, 27 Oct 2018 18:48:30 +0100
 Subject: [PATCH 09/26] Disable registry lookup unless CONDA_PY_ALLOW_REG_PATHS
@@ -37,5 +37,5 @@ index 7c0eeab5db..a73ea8a0e9 100644
         anything better to use! */
      int skipdefault = (calculate->pythonpath_env != NULL ||
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0010-Unvendor-openssl.patch
+++ b/recipe/patches/0010-Unvendor-openssl.patch
@@ -1,4 +1,4 @@
-From 4dfb0cfb41a0106a25c5e1b6a3e7bbaf2555d5a1 Mon Sep 17 00:00:00 2001
+From 8612a86106a5db10ee0374473f5f8e72f4d47266 Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sat, 24 Nov 2018 20:38:02 -0600
 Subject: [PATCH 10/26] Unvendor openssl
@@ -181,5 +181,5 @@ index e7216dec3a..247ea10d5c 100644
    <ItemGroup>
      <ProjectReference Include="pythoncore.vcxproj">
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0011-Unvendor-sqlite3.patch
+++ b/recipe/patches/0011-Unvendor-sqlite3.patch
@@ -1,4 +1,4 @@
-From ed593b77bf3cdabc1b378b7a9cb76667ac7bccb8 Mon Sep 17 00:00:00 2001
+From e93fae5562a91719067d107599105552f96a03fd Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Tue, 5 Oct 2021 12:42:06 -0700
 Subject: [PATCH 11/26] Unvendor sqlite3
@@ -88,5 +88,5 @@ index e39e2d9c22..63d1c27fbc 100644
    <ItemDefinitionGroup>
      <ClCompile>
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0012-venv-Revert-a-change-from-https-github.com-python-cp.patch
+++ b/recipe/patches/0012-venv-Revert-a-change-from-https-github.com-python-cp.patch
@@ -1,4 +1,4 @@
-From 11b00c3df53f13ba5493cb615890bf91623045bb Mon Sep 17 00:00:00 2001
+From b8c6473828078fdba549d47c11f3085c8f66d5fb Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 2 Jan 2019 21:38:48 +0000
 Subject: [PATCH 12/26] venv: Revert a change from
@@ -42,5 +42,5 @@ index 6f1af294ae..a00e89237a 100644
                  os.chmod(path, 0o755)
              for suffix in ('python', 'python3', f'python3.{sys.version_info[1]}'):
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0013-Use-ranlib-from-env-if-env-variable-is-set.patch
+++ b/recipe/patches/0013-Use-ranlib-from-env-if-env-variable-is-set.patch
@@ -1,4 +1,4 @@
-From 915f2166b8c4a5a0090ea619ef2ffa25f109888a Mon Sep 17 00:00:00 2001
+From 9f02ea94d7e0ac4bc5e6c9db86fd3ebdccd8ce79 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Sun, 3 Nov 2019 15:09:45 -0600
 Subject: [PATCH 13/26] Use ranlib from env if env variable is set
@@ -22,5 +22,5 @@ index 3414a761e7..181f66708e 100644
  
  
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0014-Add-CondaEcosystemModifyDllSearchPath.patch
+++ b/recipe/patches/0014-Add-CondaEcosystemModifyDllSearchPath.patch
@@ -195,7 +195,7 @@ index 2684d23067..ac5b151367 100644
 +            // assuming that the executable that is running this code is python.exe
 +            dll_handle = NULL;
 +        }
-+        GetModuleFileNameW(NULL, &sv_dll_dirname[0], sizeof(sv_dll_dirname)/sizeof(sv_dll_dirname[0])-1);
++        GetModuleFileNameW(dll_handle, &sv_dll_dirname[0], sizeof(sv_dll_dirname)/sizeof(sv_dll_dirname[0])-1);
 +        sv_dll_dirname[sizeof(sv_dll_dirname)/sizeof(sv_dll_dirname[0])-1] = L'\0';
 +        if (wcsrchr(sv_dll_dirname, L'\\'))
 +            *wcsrchr(sv_dll_dirname, L'\\') = L'\0';

--- a/recipe/patches/0014-Add-CondaEcosystemModifyDllSearchPath.patch
+++ b/recipe/patches/0014-Add-CondaEcosystemModifyDllSearchPath.patch
@@ -1,4 +1,4 @@
-From b80115d10d733216afdb18215257430a46a1a8ad Mon Sep 17 00:00:00 2001
+From 819812f09e088c87de969213f352c0135f98666d Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 24 Dec 2019 18:37:17 +0100
 Subject: [PATCH 14/26] Add CondaEcosystemModifyDllSearchPath()
@@ -55,13 +55,13 @@ Fix CondaEcosystemModifyDllSearchPath for users of the Python DLL
 
 Co-authored-by: Isuru Fernando <isuruf@gmail.com>
 ---
- Modules/main.c       | 363 +++++++++++++++++++++++++++++++++++++++++++
+ Modules/main.c       | 370 +++++++++++++++++++++++++++++++++++++++++++
  Python/dynload_win.c |   4 +
  Python/pylifecycle.c |   5 +-
- 3 files changed, 371 insertions(+), 1 deletion(-)
+ 3 files changed, 378 insertions(+), 1 deletion(-)
 
 diff --git a/Modules/main.c b/Modules/main.c
-index 2684d23067..f0bcb0616f 100644
+index 2684d23067..ac5b151367 100644
 --- a/Modules/main.c
 +++ b/Modules/main.c
 @@ -17,6 +17,10 @@
@@ -75,7 +75,7 @@ index 2684d23067..f0bcb0616f 100644
  #endif
  /* End of includes for exit_sigint() */
  
-@@ -680,10 +684,369 @@ Py_RunMain(void)
+@@ -680,10 +684,376 @@ Py_RunMain(void)
      return exitcode;
  }
  
@@ -140,8 +140,6 @@ index 2684d23067..f0bcb0616f 100644
 +static SDD pSetDllDirectory = NULL;
 +static ADD pAddDllDirectory = NULL;
 +static int sv_failed_to_find_dll_fns = 0;
-+/* sv_executable_dirname is gotten but not used ATM. */
-+static wchar_t sv_executable_dirname[1024];
 +/* Have hidden this behind a define because it is clearly not code that
 +   could be considered for upstreaming so clearly delimiting it makes it
 +   easier to remove. */
@@ -164,7 +162,7 @@ index 2684d23067..f0bcb0616f 100644
 +    {L"bin", NULL}
 +};
 +#endif /* HARDCODE_CONDA_PATHS */
-+static wchar_t sv_executable_dirname[1024];
++static wchar_t sv_dll_dirname[1024];
 +static wchar_t sv_windows_directory[1024];
 +static wchar_t *sv_added_windows_directory = NULL;
 +static wchar_t *sv_added_cwd = NULL;
@@ -178,6 +176,7 @@ index 2684d23067..f0bcb0616f 100644
 +    long long j;
 +    CONDA_PATH *p_conda_path;
 +#endif /* defined(HARDCODE_CONDA_PATHS) */
++    HMODULE dll_handle = NULL;
 +
 +    if (pSetDefaultDllDirectories == NULL)
 +    {
@@ -188,18 +187,26 @@ index 2684d23067..f0bcb0616f 100644
 +        pSetDllDirectory = (SDD)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "SetDllDirectoryW");
 +        pAddDllDirectory = (ADD)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")), "AddDllDirectory");
 +
-+        /* Determine sv_executable_dirname */
-+        GetModuleFileNameW(NULL, &sv_executable_dirname[0], sizeof(sv_executable_dirname)/sizeof(sv_executable_dirname[0])-1);
-+        sv_executable_dirname[sizeof(sv_executable_dirname)/sizeof(sv_executable_dirname[0])-1] = L'\0';
-+        if (wcsrchr(sv_executable_dirname, L'\\'))
-+            *wcsrchr(sv_executable_dirname, L'\\') = L'\0';
++        /* Determine sv_dll_dirname */
++        if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
++            (LPCSTR) &CondaEcosystemModifyDllSearchPath_Init, &dll_handle) == 0)
++        {
++            // Getting the pythonxx.dll path failed. Fall back to relative path of python.exe
++            // assuming that the executable that is running this code is python.exe
++            dll_handle = NULL;
++        }
++        GetModuleFileNameW(NULL, &sv_dll_dirname[0], sizeof(sv_dll_dirname)/sizeof(sv_dll_dirname[0])-1);
++        sv_dll_dirname[sizeof(sv_dll_dirname)/sizeof(sv_dll_dirname[0])-1] = L'\0';
++        if (wcsrchr(sv_dll_dirname, L'\\'))
++            *wcsrchr(sv_dll_dirname, L'\\') = L'\0';
++
 +#if defined(HARDCODE_CONDA_PATHS)
 +        for (p_conda_path = &condaPaths[0]; p_conda_path < &condaPaths[NUM_CONDA_PATHS]; ++p_conda_path)
 +        {
-+            size_t n_chars_executable_dirname = wcslen(sv_executable_dirname);
++            size_t n_chars_dll_dirname = wcslen(sv_dll_dirname);
 +            size_t n_chars_p_relative = wcslen(p_conda_path->p_relative);
-+            p_conda_path->p_name = malloc(sizeof(wchar_t) * (n_chars_executable_dirname + n_chars_p_relative + 2));
-+            wcsncpy(p_conda_path->p_name, sv_executable_dirname, n_chars_executable_dirname+1);
++            p_conda_path->p_name = malloc(sizeof(wchar_t) * (n_chars_dll_dirname + n_chars_p_relative + 2));
++            wcsncpy(p_conda_path->p_name, sv_dll_dirname, n_chars_dll_dirname+1);
 +            wcsncat(p_conda_path->p_name, L"\\", 2);
 +            wcsncat(p_conda_path->p_name, p_conda_path->p_relative, n_chars_p_relative+1);
 +        }
@@ -477,5 +484,5 @@ index eeaf20b461..a32aa666e4 100644
  }
  
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0015-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
+++ b/recipe/patches/0015-Add-d1trimfile-SRC_DIR-to-make-pdbs-more-relocatable.patch
@@ -1,4 +1,4 @@
-From fa05e6d837fdfc86cf3c6c6e5fd20b770f33a578 Mon Sep 17 00:00:00 2001
+From c17e952ac5350fd2f04298c77234e4bc1f151d98 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 31 Dec 2019 20:46:36 +0100
 Subject: [PATCH 15/26] Add /d1trimfile:%SRC_DIR% to make pdbs more relocatable
@@ -35,5 +35,5 @@ index af8099a407..0b245adb30 100644
                  args.append('/EHsc')
              args.append(input_opt)
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0016-Doing-d1trimfile.patch
+++ b/recipe/patches/0016-Doing-d1trimfile.patch
@@ -1,4 +1,4 @@
-From 318a22baf1b7e0c786f2bce78086796655ab896e Mon Sep 17 00:00:00 2001
+From 6a7e914deb751836f2207bffa15f6dddb1a067dc Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 31 Dec 2019 21:47:47 +0100
 Subject: [PATCH 16/26] Doing d1trimfile
@@ -877,5 +877,5 @@ index dd830b3b6a..fef2c5b9f4 100644
        <AdditionalDependencies>wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
      </Link>
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0017-cross-compile-darwin.patch
+++ b/recipe/patches/0017-cross-compile-darwin.patch
@@ -1,4 +1,4 @@
-From 9eb1b4ff8f9b338792747b4afff93f0f22a5aaa0 Mon Sep 17 00:00:00 2001
+From 755a6f064c96397e839d4e2bc7054106f6cbf85d Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Fri, 2 Oct 2020 00:03:12 +0200
 Subject: [PATCH 17/26] cross compile darwin
@@ -103,5 +103,5 @@ index d5bbeb90d5..e3354101e6 100644
              else:
                  ret = 1
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0018-Fix-TZPATH-on-windows.patch
+++ b/recipe/patches/0018-Fix-TZPATH-on-windows.patch
@@ -1,4 +1,4 @@
-From 8aceb54853d441932527d6f028a219150baaefed Mon Sep 17 00:00:00 2001
+From 2361d165623ff6a5c2e70b342b237797eb4fcb85 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 7 Oct 2020 10:08:30 -0500
 Subject: [PATCH 18/26] Fix TZPATH on windows
@@ -20,5 +20,5 @@ index daf9f00006..5d12426756 100644
              _init_posix(_CONFIG_VARS)
          # For backward compatibility, see issue19555
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0019-Make-dyld-search-work-with-SYSTEM_VERSION_COMPAT-1.patch
+++ b/recipe/patches/0019-Make-dyld-search-work-with-SYSTEM_VERSION_COMPAT-1.patch
@@ -1,4 +1,4 @@
-From beb5d2d0b29739c831c09cefcc88b565e565d851 Mon Sep 17 00:00:00 2001
+From 0affef0c7ec9b3469de756ccac647cad22a44b29 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 25 Jan 2021 03:28:08 -0600
 Subject: [PATCH 19/26] Make dyld search work with SYSTEM_VERSION_COMPAT=1
@@ -28,5 +28,5 @@ index ddf289e3e8..b7c5504d03 100644
  // Support the deprecated case of compiling on an older macOS version
  static void *libsystem_b_handle;
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0020-Fix-LDSHARED-when-CC-is-overriden-on-Linux-too.patch
+++ b/recipe/patches/0020-Fix-LDSHARED-when-CC-is-overriden-on-Linux-too.patch
@@ -1,4 +1,4 @@
-From 6d45c95bd28f6e4789d1348f8162710d826ee587 Mon Sep 17 00:00:00 2001
+From 991b11bba6b4f83007a1be776559982cf597746e Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 02:18:50 -0700
 Subject: [PATCH 20/26] Fix LDSHARED when CC is overriden on Linux too
@@ -25,5 +25,5 @@ index 181f66708e..07bb42df04 100644
                  ldshared = newcc + ldshared[len(cc):]
              cc = newcc
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0021-Unvendor-bzip2.patch
+++ b/recipe/patches/0021-Unvendor-bzip2.patch
@@ -1,4 +1,4 @@
-From f2c8279f6670c57d9a7c1e246ce04b532f44bed7 Mon Sep 17 00:00:00 2001
+From 956f07f90f14a28ef1d34afaf50256bceed5e7e8 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 02:56:27 -0700
 Subject: [PATCH 21/26] Unvendor bzip2
@@ -86,5 +86,5 @@ index 7c0b516253..c1f960608c 100644
      </ClInclude>
    </ItemGroup>
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0022-Unvendor-libffi.patch
+++ b/recipe/patches/0022-Unvendor-libffi.patch
@@ -1,4 +1,4 @@
-From 1bba2909f069c2b22393131c076bdfca92fbcdaa Mon Sep 17 00:00:00 2001
+From 48ca4acc35dffbe3af882513a11442ae1e27ad46 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 03:07:40 -0700
 Subject: [PATCH 22/26] Unvendor libffi
@@ -37,5 +37,5 @@ index 975c4a0d35..97fb5966bf 100644
  </Project>
 \ No newline at end of file
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0023-Unvendor-tcltk.patch
+++ b/recipe/patches/0023-Unvendor-tcltk.patch
@@ -1,4 +1,4 @@
-From d976e587a514b511df1f189f9d6745531297e85a Mon Sep 17 00:00:00 2001
+From 85080cba2e0450b9e1405b885bf629c14f9c5856 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Fri, 20 Aug 2021 10:23:51 -0700
 Subject: [PATCH 23/26] Unvendor tcltk
@@ -27,5 +27,5 @@ index 16dc35d45e..f0ae3372f3 100644
      <tclDLLName>tcl$(TclMajorVersion)$(TclMinorVersion)t$(TclDebugExt).dll</tclDLLName>
      <tclLibName>tcl$(TclMajorVersion)$(TclMinorVersion)t$(TclDebugExt).lib</tclLibName>
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0024-unvendor-xz.patch
+++ b/recipe/patches/0024-unvendor-xz.patch
@@ -1,4 +1,4 @@
-From d31618aeb588ef1e4e4667974beb3103eba6f3cd Mon Sep 17 00:00:00 2001
+From ee6c575b1e17da5bef452ba3ffc0b1c44e878ba2 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Sat, 25 Sep 2021 10:07:05 -0700
 Subject: [PATCH 24/26] unvendor xz
@@ -42,5 +42,5 @@ index 0565132363..e8b2704cee 100644
    <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
    <ImportGroup Label="ExtensionTargets">
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0025-unvendor-zlib.patch
+++ b/recipe/patches/0025-unvendor-zlib.patch
@@ -1,4 +1,4 @@
-From 7e1a3d59af5be5aca5b1361e5b0586390685fa26 Mon Sep 17 00:00:00 2001
+From a35e0d69abd36e0a748f432b7ad248d4b92d46ad Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 29 Sep 2021 15:21:55 -0700
 Subject: [PATCH 25/26] unvendor zlib
@@ -160,5 +160,5 @@ index 55b57ef29d..2fc1a57161 100644
        <Filter>Python</Filter>
      </ClCompile>
 -- 
-2.35.0
+2.28.0
 

--- a/recipe/patches/0026-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
+++ b/recipe/patches/0026-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
@@ -1,4 +1,4 @@
-From c75242b4fa4eb7384af04a64d17a2d637ebe5ac2 Mon Sep 17 00:00:00 2001
+From ce3ad7e175e1558aa7a5c72be3b47ae5b97d5f7d Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:45:28 +0100
 Subject: [PATCH 26/26] Do not pass -g to GCC when not Py_DEBUG
@@ -48,5 +48,5 @@ index 890aae7ea1..c69181d1e8 100644
  	    ;;
  	*)
 -- 
-2.35.0
+2.28.0
 


### PR DESCRIPTION
Instead of the current executable path which may or may not
be python.exe

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
