### PR TITLE
Check CONFIGS env variable in run_osx_build.sh

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -40,9 +40,10 @@ if [ -z "$CONFIG" ]; then
     FILES=`ls .ci_support/linux_*`
     CONFIGS=""
     for file in $FILES; do
-        CONFIGS="${CONFIGS}'${file:12:-5}' or ";
+        file=${file/\.yaml/}
+        CONFIGS="${CONFIGS}'${file:12}' or ";
     done
-    echo "Need to set CONFIG env variable. Value can be one of ${CONFIGS:0:-4}"
+    echo "Need to set CONFIG env variable. Value can be one of ${CONFIGS:0:${#CONFIGS}-4}"
     exit 1
 fi
 

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,6 +6,18 @@ source .scripts/logging_utils.sh
 
 set -xe
 
+if [ -z "$CONFIG" ]; then
+    set +x
+    FILES=`ls .ci_support/osx_*`
+    CONFIGS=""
+    for file in $FILES; do
+        file=${file/\.yaml/}
+        CONFIGS="${CONFIGS}'${file:12}' or ";
+    done
+    echo "Need to set CONFIG env variable. Value can be one of ${CONFIGS:0:${#CONFIGS}-4}"
+    exit 1
+fi
+
 MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
@@ -28,8 +40,6 @@ mamba install --update-specs --quiet --yes --channel conda-forge \
     conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
     conda-build pip boa conda-forge-ci-setup=3
-
-
 
 echo -e "\n\nSetting up the condarc and mangling the compiler."
 setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

## Updates

Without the CONFIGS env variable being set, one will run into an error such as:

```
Invalid value for 'CONFIG_FILE': File './.ci_support/.yaml' does not exist.
```

This check is in a similar vein as .scripts/run_docker_build.sh.

Also, negative lengths are not allowed in bash 3.x (added in 4.2);
a few lines for string manipiulation are modified for better bash compatibility.
