### PR TITLE
[ci skip] adding user @chrisburr

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @isuruf @jakirkham @katietz @mbargull @mingwandroid @msarahan @ocefpaf @pelson @scopatz @xhochy
+* @chrisburr @isuruf @jakirkham @katietz @mbargull @mingwandroid @msarahan @ocefpaf @pelson @scopatz @xhochy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -314,6 +314,7 @@ about:
 extra:
   feedstock-name: python
   recipe-maintainers:
+    - chrisburr
     - isuruf
     - jakirkham
     - mbargull


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @chrisburr as instructed in #590.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Please contact [conda-forge/core](https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-contact-core) to have this PR merged, if the maintainer is unresponsive.

Fixes #590