### PR TITLE
Add 3.10 and 3.11 to abi migrations

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,7 +4,6 @@ provider: {linux_aarch64: default, linux_ppc64le: native}
 test_on_native_only: true
 bot:
   abi_migration_branches:
-  - "3.7"
   - "3.8"
   - "3.9"
   - "3.10"

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,9 +4,11 @@ provider: {linux_aarch64: default, linux_ppc64le: native}
 test_on_native_only: true
 bot:
   abi_migration_branches:
-  - 3.7
-  - 3.8
-  - 3.9
+  - "3.7"
+  - "3.8"
+  - "3.9"
+  - "3.10"
+  - "3.11"
 azure:
   store_build_artifacts: true
 github:


### PR DESCRIPTION
I just created 3.11 and also quoted the branches to avoid YAML parsing issues.