### PR TITLE
Python 3.12.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,11 +8,11 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_build_typedebugchannel_targetsconda-forge_python_rc_debug:
-        CONFIG: linux_64_build_typedebugchannel_targetsconda-forge_python_rc_debug
+      linux_64_build_typedebugchannel_targetsconda-forge_python_debug:
+        CONFIG: linux_64_build_typedebugchannel_targetsconda-forge_python_debug
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_build_typedebugchannel_tar_h3ac49dcecd
+        SHORT_CONFIG: linux_64_build_typedebugchannel_tar_hcab9fe8502
       linux_64_build_typereleasechannel_targetsconda-forge_main:
         CONFIG: linux_64_build_typereleasechannel_targetsconda-forge_main
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,18 +8,18 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_build_typedebugchannel_targetsconda-forge_python_rc_debug:
-        CONFIG: osx_64_build_typedebugchannel_targetsconda-forge_python_rc_debug
+      osx_64_build_typedebugchannel_targetsconda-forge_python_debug:
+        CONFIG: osx_64_build_typedebugchannel_targetsconda-forge_python_debug
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_build_typedebugchannel_targe_h5bbcd659fa
+        SHORT_CONFIG: osx_64_build_typedebugchannel_targe_h343640355d
       osx_64_build_typereleasechannel_targetsconda-forge_main:
         CONFIG: osx_64_build_typereleasechannel_targetsconda-forge_main
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: osx_64_build_typereleasechannel_tar_h217401936b
-      osx_arm64_build_typedebugchannel_targetsconda-forge_python_rc_debug:
-        CONFIG: osx_arm64_build_typedebugchannel_targetsconda-forge_python_rc_debug
+      osx_arm64_build_typedebugchannel_targetsconda-forge_python_debug:
+        CONFIG: osx_arm64_build_typedebugchannel_targetsconda-forge_python_debug
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_arm64_build_typedebugchannel_ta_haae78a064e
+        SHORT_CONFIG: osx_arm64_build_typedebugchannel_ta_h18126b8f59
       osx_arm64_build_typereleasechannel_targetsconda-forge_main:
         CONFIG: osx_arm64_build_typereleasechannel_targetsconda-forge_main
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
+++ b/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
@@ -9,9 +9,9 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
-- conda-forge python_rc_debug
+- conda-forge python_debug
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_main.yaml
+++ b/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_main.yaml
@@ -9,7 +9,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
+++ b/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
@@ -1,27 +1,33 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 build_type:
 - debug
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '15'
+- '12'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
-- conda-forge python_rc_debug
+- conda-forge python_debug
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 expat:
 - '2'
 libffi:
 - '3.4'
-macos_machine:
-- arm64-apple-darwin20.0.0
+libuuid:
+- '2'
 ncurses:
 - '6'
 openssl:
@@ -37,7 +43,7 @@ readline:
 sqlite:
 - '3'
 target_platform:
-- osx-arm64
+- linux-aarch64
 tk:
 - '8.6'
 xz:

--- a/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_main.yaml
+++ b/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_main.yaml
@@ -13,7 +13,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debug.yaml
+++ b/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debug.yaml
@@ -1,29 +1,29 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
-MACOSX_SDK_VERSION:
-- '11.0'
 build_type:
 - debug
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '15'
+- '12'
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
-- conda-forge python_rc_debug
+- conda-forge python_debug
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '15'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 expat:
 - '2'
 libffi:
 - '3.4'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+libuuid:
+- '2'
 ncurses:
 - '6'
 openssl:
@@ -39,9 +39,7 @@ readline:
 sqlite:
 - '3'
 target_platform:
-- osx-64
-tk:
-- '8.6'
+- linux-ppc64le
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_main.yaml
+++ b/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_main.yaml
@@ -9,7 +9,7 @@ c_compiler_version:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
+++ b/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
@@ -1,29 +1,29 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+MACOSX_SDK_VERSION:
+- '11.0'
 build_type:
 - debug
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_name:
-- cos7
+- '15'
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
-- conda-forge python_rc_debug
+- conda-forge python_debug
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-ppc64le
+- '15'
 expat:
 - '2'
 libffi:
 - '3.4'
-libuuid:
-- '2'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 ncurses:
 - '6'
 openssl:
@@ -39,7 +39,9 @@ readline:
 sqlite:
 - '3'
 target_platform:
-- linux-ppc64le
+- osx-64
+tk:
+- '8.6'
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_main.yaml
+++ b/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_main.yaml
@@ -11,7 +11,7 @@ c_compiler:
 c_compiler_version:
 - '15'
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
+++ b/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
@@ -1,33 +1,27 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 build_type:
 - debug
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '15'
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
-- conda-forge python_rc_debug
+- conda-forge python_debug
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- '15'
 expat:
 - '2'
 libffi:
 - '3.4'
-libuuid:
-- '2'
+macos_machine:
+- arm64-apple-darwin20.0.0
 ncurses:
 - '6'
 openssl:
@@ -43,7 +37,7 @@ readline:
 sqlite:
 - '3'
 target_platform:
-- linux-aarch64
+- osx-arm64
 tk:
 - '8.6'
 xz:

--- a/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_main.yaml
+++ b/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_main.yaml
@@ -9,7 +9,7 @@ c_compiler:
 c_compiler_version:
 - '15'
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -5,7 +5,7 @@ bzip2:
 c_compiler:
 - vs2019
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_aarch64_build_typedebugchannel_targetsconda-forge_python_rc_debug UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
+    - env: CONFIG=linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debug UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64
       os: linux
       arch: arm64
       dist: focal
@@ -17,7 +17,7 @@ matrix:
       arch: arm64
       dist: focal
 
-    - env: CONFIG=linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_rc_debug UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debug UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
       dist: focal

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_build_typedebugchannel_targetsconda-forge_python_rc_debug</td>
+              <td>linux_64_build_typedebugchannel_targetsconda-forge_python_debug</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_typedebugchannel_targetsconda-forge_python_rc_debug" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_typedebugchannel_targetsconda-forge_python_debug" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -60,10 +60,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_build_typedebugchannel_targetsconda-forge_python_rc_debug</td>
+              <td>linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debug</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_build_typedebugchannel_targetsconda-forge_python_rc_debug" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debug" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -74,10 +74,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_rc_debug</td>
+              <td>linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debug</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_rc_debug" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debug" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -88,10 +88,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_build_typedebugchannel_targetsconda-forge_python_rc_debug</td>
+              <td>osx_64_build_typedebugchannel_targetsconda-forge_python_debug</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_build_typedebugchannel_targetsconda-forge_python_rc_debug" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_build_typedebugchannel_targetsconda-forge_python_debug" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -102,10 +102,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_build_typedebugchannel_targetsconda-forge_python_rc_debug</td>
+              <td>osx_arm64_build_typedebugchannel_targetsconda-forge_python_debug</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_build_typedebugchannel_targetsconda-forge_python_rc_debug" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_build_typedebugchannel_targetsconda-forge_python_debug" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,8 +9,6 @@ MACOSX_SDK_VERSION:            # [osx and x86_64]
 build_type:
   - release
   - debug                      # [not win]
-channel_sources:
-  - conda-forge/label/python_rc,conda-forge
 channel_targets:
   - conda-forge main
   - conda-forge python_debug   # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,10 @@
 {% set version = "3.12.0" %}
-{% set dev = "rc3" %}
-{% set dev_ = "rc3_" %}
+{% set dev = "" %}
+{% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 1 %}
+{% set build_number = 0 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}
@@ -46,7 +46,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}{{ dev }}/
-    md5: cead7d4428e88e8de9219731c21edb74
+    md5: f6f4616584b23254d165f4db90c247d6
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch

--- a/recipe/patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
+++ b/recipe/patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
@@ -1,4 +1,4 @@
-From 5bdb40fdc8c6fce6f6770dff2f9e97db1b1f6391 Mon Sep 17 00:00:00 2001
+From 9c65249a545fe5c296a72d6b823d9d3243253be7 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:53:55 +0100
 Subject: [PATCH 01/21] Win32: Change FD_SETSIZE from 512 to 2048

--- a/recipe/patches/0002-Win32-Do-not-download-externals.patch
+++ b/recipe/patches/0002-Win32-Do-not-download-externals.patch
@@ -1,4 +1,4 @@
-From befb192e6f80b62a8b3975dce6cbd5d5b033dbb1 Mon Sep 17 00:00:00 2001
+From f1e63f55ede50edbac1e8135375ba3985eab141d Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Thu, 7 Sep 2017 11:35:47 +0100
 Subject: [PATCH 02/21] Win32: Do not download externals

--- a/recipe/patches/0003-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
+++ b/recipe/patches/0003-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -1,4 +1,4 @@
-From a0ee25bbb5b930c076b1f21ff010fb771936bb09 Mon Sep 17 00:00:00 2001
+From 26c9a5f3c60ebf2513bdbde146eda9c23720fd4e Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 5 Dec 2017 22:47:59 +0000
 Subject: [PATCH 03/21] Fix find_library so that it looks in sys.prefix/lib

--- a/recipe/patches/0004-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
+++ b/recipe/patches/0004-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
@@ -1,4 +1,4 @@
-From 23e3234467d3bccd6ee39cb8171c346aa97d7e80 Mon Sep 17 00:00:00 2001
+From 3764b2e5a0373e1b5611e84fcae69c8354cff7d6 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sat, 27 Oct 2018 18:48:30 +0100
 Subject: [PATCH 04/21] Disable registry lookup unless CONDA_PY_ALLOW_REG_PATHS

--- a/recipe/patches/0005-Unvendor-openssl.patch
+++ b/recipe/patches/0005-Unvendor-openssl.patch
@@ -1,4 +1,4 @@
-From 99fe809142a3896dff90dd5be01807c164e1eb75 Mon Sep 17 00:00:00 2001
+From 4caed7d1cc16c2c7cbc151297aa27d1e51f30f87 Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sat, 24 Nov 2018 20:38:02 -0600
 Subject: [PATCH 05/21] Unvendor openssl
@@ -144,7 +144,7 @@ index 0da6f67495..17eee400eb 100644
    <Target Name="CleanAll">
      <Delete Files="$(TargetPath);$(BuildPath)$(tclDLLName)" />
 diff --git a/PCbuild/python.props b/PCbuild/python.props
-index 94faa8221e..cf0913f331 100644
+index 35c6e92be4..cf0913f331 100644
 --- a/PCbuild/python.props
 +++ b/PCbuild/python.props
 @@ -61,6 +61,7 @@
@@ -165,8 +165,8 @@ index 94faa8221e..cf0913f331 100644
 -    <libffiDir Condition="$(libffiDir) == ''">$(ExternalsDir)libffi-3.4.4\</libffiDir>
 -    <libffiOutDir Condition="$(libffiOutDir) == ''">$(libffiDir)$(ArchName)\</libffiOutDir>
 -    <libffiIncludeDir Condition="$(libffiIncludeDir) == ''">$(libffiOutDir)include</libffiIncludeDir>
--    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.10\</opensslDir>
--    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.10\$(ArchName)\</opensslOutDir>
+-    <opensslDir Condition="$(opensslDir) == ''">$(ExternalsDir)openssl-3.0.11\</opensslDir>
+-    <opensslOutDir Condition="$(opensslOutDir) == ''">$(ExternalsDir)openssl-bin-3.0.11\$(ArchName)\</opensslOutDir>
 -    <opensslIncludeDir Condition="$(opensslIncludeDir) == ''">$(opensslOutDir)include</opensslIncludeDir>
      <nasmDir Condition="$(nasmDir) == ''">$(ExternalsDir)\nasm-2.11.06\</nasmDir>
 -    <zlibDir Condition="$(zlibDir) == ''">$(ExternalsDir)\zlib-1.2.13\</zlibDir>

--- a/recipe/patches/0006-Unvendor-sqlite3.patch
+++ b/recipe/patches/0006-Unvendor-sqlite3.patch
@@ -1,4 +1,4 @@
-From df95082bb1e96ce6f49949d60eedde992cdde03d Mon Sep 17 00:00:00 2001
+From b39c8fd16e03f7f177f7854f65f0c2d3dccd03d1 Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Tue, 5 Oct 2021 12:42:06 -0700
 Subject: [PATCH 06/21] Unvendor sqlite3

--- a/recipe/patches/0007-Add-CondaEcosystemModifyDllSearchPath.patch
+++ b/recipe/patches/0007-Add-CondaEcosystemModifyDllSearchPath.patch
@@ -1,4 +1,4 @@
-From 5fd4be6005d39c58c9739a7518f243d1ea4b63a5 Mon Sep 17 00:00:00 2001
+From ea4bacd76a8b7845ea62dec463d37cc097d7fb9c Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 24 Dec 2019 18:37:17 +0100
 Subject: [PATCH 07/21] Add CondaEcosystemModifyDllSearchPath()

--- a/recipe/patches/0008-Doing-d1trimfile.patch
+++ b/recipe/patches/0008-Doing-d1trimfile.patch
@@ -1,4 +1,4 @@
-From fb9d98398f49caa104467c41b8d23891426477d4 Mon Sep 17 00:00:00 2001
+From 5fc2ffd45d611825e2aefa412524d3e9fd99639a Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 31 Dec 2019 21:47:47 +0100
 Subject: [PATCH 08/21] Doing d1trimfile

--- a/recipe/patches/0009-cross-compile-darwin.patch
+++ b/recipe/patches/0009-cross-compile-darwin.patch
@@ -1,4 +1,4 @@
-From 63959de9af24cf2b696dddec31e33f7f85fda339 Mon Sep 17 00:00:00 2001
+From 761d19a67f9e7bf5a478c83485026e264b231af1 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Fri, 2 Oct 2020 00:03:12 +0200
 Subject: [PATCH 09/21] cross compile darwin

--- a/recipe/patches/0010-Fix-TZPATH-on-windows.patch
+++ b/recipe/patches/0010-Fix-TZPATH-on-windows.patch
@@ -1,4 +1,4 @@
-From 6cdabad153ba90aedf6c2b1b9f3f911e1601c689 Mon Sep 17 00:00:00 2001
+From 4e7cb1045c53355ff9adc649e7fad73ef2b0fee9 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 7 Oct 2020 10:08:30 -0500
 Subject: [PATCH 10/21] Fix TZPATH on windows

--- a/recipe/patches/0011-Make-dyld-search-work-with-SYSTEM_VERSION_COMPAT-1.patch
+++ b/recipe/patches/0011-Make-dyld-search-work-with-SYSTEM_VERSION_COMPAT-1.patch
@@ -1,4 +1,4 @@
-From 91ad1580106357c51cf2b81c5f30a2bac4909fce Mon Sep 17 00:00:00 2001
+From 2994bf0c4feb1e5d6f3858054114cbf192a4a60a Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 25 Jan 2021 03:28:08 -0600
 Subject: [PATCH 11/21] Make dyld search work with SYSTEM_VERSION_COMPAT=1

--- a/recipe/patches/0012-Unvendor-bzip2.patch
+++ b/recipe/patches/0012-Unvendor-bzip2.patch
@@ -1,4 +1,4 @@
-From 6666bbb1790d683b5bc7dd997ac6d44e9681158c Mon Sep 17 00:00:00 2001
+From 6f6760a46f464e90ab9bdf74c392c847ad43988c Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 02:56:27 -0700
 Subject: [PATCH 12/21] Unvendor bzip2

--- a/recipe/patches/0013-Unvendor-libffi.patch
+++ b/recipe/patches/0013-Unvendor-libffi.patch
@@ -1,4 +1,4 @@
-From 56fadcadf4ebf8eb09e815101e9c8149cda583c5 Mon Sep 17 00:00:00 2001
+From e1a87bdb6330dee875e55f0dddf1bf803d86107e Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 03:07:40 -0700
 Subject: [PATCH 13/21] Unvendor libffi

--- a/recipe/patches/0014-Unvendor-tcltk.patch
+++ b/recipe/patches/0014-Unvendor-tcltk.patch
@@ -1,4 +1,4 @@
-From d099a5686041ff74fe31d487890e390d0d75fdea Mon Sep 17 00:00:00 2001
+From 05e634c618dc84e058ce4ad32e94f50905833dee Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Fri, 20 Aug 2021 10:23:51 -0700
 Subject: [PATCH 14/21] Unvendor tcltk

--- a/recipe/patches/0015-unvendor-xz.patch
+++ b/recipe/patches/0015-unvendor-xz.patch
@@ -1,4 +1,4 @@
-From 31e4b84a08ce2fa0bc280c79f67143fa5ca622af Mon Sep 17 00:00:00 2001
+From a371f3684e2b685bc98815cb7c1057eedcbf039a Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Sat, 25 Sep 2021 10:07:05 -0700
 Subject: [PATCH 15/21] unvendor xz

--- a/recipe/patches/0016-unvendor-zlib.patch
+++ b/recipe/patches/0016-unvendor-zlib.patch
@@ -1,4 +1,4 @@
-From ad6b3f24b6d6c6663d66804c652b53734a1d4a00 Mon Sep 17 00:00:00 2001
+From 71166dd830423aff95cf3f5104d00911e9406883 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 29 Sep 2021 15:21:55 -0700
 Subject: [PATCH 16/21] unvendor zlib

--- a/recipe/patches/0017-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
+++ b/recipe/patches/0017-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
@@ -1,4 +1,4 @@
-From 11f3cfab6d1f545a94010ed3e42d002f3698a8b5 Mon Sep 17 00:00:00 2001
+From 44941693b8925d8404f844cd6d2d84b6be2748be Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:45:28 +0100
 Subject: [PATCH 17/21] Do not pass -g to GCC when not Py_DEBUG

--- a/recipe/patches/0018-Unvendor-expat.patch
+++ b/recipe/patches/0018-Unvendor-expat.patch
@@ -1,4 +1,4 @@
-From eec3d786f18cbe7bb4bd3f5120a1d9337ea7c44b Mon Sep 17 00:00:00 2001
+From 060eb5f19be1a8e54ff793d42ee84a1a0075c0d9 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 29 Mar 2023 23:07:10 -0500
 Subject: [PATCH 18/21] Unvendor expat

--- a/recipe/patches/0019-Remove-unused-readelf.patch
+++ b/recipe/patches/0019-Remove-unused-readelf.patch
@@ -1,4 +1,4 @@
-From a76ef7db2fa773f66cec71f2c0cfeb2397ea7237 Mon Sep 17 00:00:00 2001
+From 578f1d963cb9354e949e87aa18af1a1da91e60b5 Mon Sep 17 00:00:00 2001
 From: Charles Bousseau <cbousseau@anaconda.com>
 Date: Thu, 25 May 2023 17:56:53 -0400
 Subject: [PATCH 19/21] Remove unused readelf

--- a/recipe/patches/0020-Don-t-checksharedmods-if-cross-compiling.patch
+++ b/recipe/patches/0020-Don-t-checksharedmods-if-cross-compiling.patch
@@ -1,4 +1,4 @@
-From 6c35e24c3fc3e1b4b7533e838a7bd27dd9c3648c Mon Sep 17 00:00:00 2001
+From c5a882bb5d113b33569d4ec73e5f44b05197e1a6 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Fri, 1 Sep 2023 23:32:14 +0200
 Subject: [PATCH 20/21] Don't checksharedmods if cross-compiling

--- a/recipe/patches/0021-Override-configure-LIBFFI.patch
+++ b/recipe/patches/0021-Override-configure-LIBFFI.patch
@@ -1,4 +1,4 @@
-From 6b49d42b7038ec0f08c284531543f400e66f4e5e Mon Sep 17 00:00:00 2001
+From 2cd21584073d8a41dcbb86f695d86b82d1c45de0 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Tue, 5 Sep 2023 21:51:31 +0200
 Subject: [PATCH 21/21] Override configure LIBFFI


### PR DESCRIPTION
Essentially all the work was done in #636, plus a little bit in #642 & #648. Due to the switch introduced in #648 
https://github.com/conda-forge/python-feedstock/blob/7614a9b8443e983309ae97805abf86eb67696eb3/recipe/meta.yaml#L182-L184

we don't have to update the channels for this PR.