### PR TITLE
Support abi3 packages with a python version independent site-packages directory

### DIFF
--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -534,3 +534,6 @@ fi
 # Workaround for old conda versions which fail to install noarch packages for Python 3.10+
 # https://github.com/conda/conda/issues/10969
 ln -s "${PREFIX}/lib/python${VER}" "${PREFIX}/lib/python3.1"
+
+# Add a custom site-packages dir ${PREFIX}/lib/site-packages to install abi3 packages
+cp "${RECIPE_DIR}/sitecustomize.py" "${PREFIX}/lib/python${VER}/sitecustomize.py"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}

--- a/recipe/sitecustomize.py
+++ b/recipe/sitecustomize.py
@@ -1,2 +1,2 @@
 import site, sys, os
-site.addsitedir(os.path.join(sys.prefix, 'lib', 'site-packages'))
+site.addsitedir(os.path.join(sys.prefix, 'lib', 'python', 'site-packages'))

--- a/recipe/sitecustomize.py
+++ b/recipe/sitecustomize.py
@@ -1,0 +1,2 @@
+import site, sys, os
+site.addsitedir(os.path.join(sys.prefix, 'lib', 'site-packages'))


### PR DESCRIPTION
cc @conda-forge/core

When building abi3 packages, we just need to do `export PIP_TARGET=$PREFIX/lib/site-packages` when building downstreams and then everything else should work properly. (We also have to fix the metadata in `meta.yaml` in downstream recipes.