### PR TITLE
python 3.11.9

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -19,6 +19,7 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: linux_64_build_typereleasechannel_t_h0a44af7c38
   timeoutInMinutes: 360
+  variables: {}
 
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -25,6 +25,7 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: osx_arm64_build_typereleasechannel__hbf952199ba
   timeoutInMinutes: 360
+  variables: {}
 
   steps:
   # TODO: Fast finish on azure pipelines?

--- a/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
+++ b/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
@@ -6,6 +6,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -49,5 +53,7 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 zlib:
 - '1.2'

--- a/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_main.yaml
+++ b/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_main.yaml
@@ -6,6 +6,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -49,5 +53,7 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 zlib:
 - '1.2'

--- a/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
+++ b/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -53,5 +57,7 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 zlib:
 - '1.2'

--- a/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_main.yaml
+++ b/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_main.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -53,5 +57,7 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 zlib:
 - '1.2'

--- a/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debug.yaml
+++ b/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debug.yaml
@@ -6,6 +6,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -47,5 +51,7 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 zlib:
 - '1.2'

--- a/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_main.yaml
+++ b/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_main.yaml
@@ -6,6 +6,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cdt_name:
 - cos7
 channel_sources:
@@ -47,5 +51,7 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 zlib:
 - '1.2'

--- a/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
+++ b/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
@@ -10,6 +10,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_main.yaml
+++ b/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_main.yaml
@@ -10,6 +10,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
+++ b/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debug.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_main.yaml
+++ b/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_main.yaml
@@ -8,6 +8,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -4,6 +4,8 @@ bzip2:
 - '1'
 c_compiler:
 - vs2019
+c_stdlib:
+- vs
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -76,7 +76,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,9 +26,9 @@ export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 
 
@@ -81,7 +81,7 @@ else
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
     fi
 
-    conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -24,7 +24,7 @@ set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration
@@ -55,7 +55,7 @@ call :end_group
 
 :: Build the recipe
 echo Building recipe
-conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Prepare some environment variables for the upload step

--- a/README.md
+++ b/README.md
@@ -141,14 +141,14 @@ Current release info
 Installing python
 =================
 
-Installing `python` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `python` from the `conda-forge/label/python_debug` channel can be achieved by adding `conda-forge/label/python_debug` to your channels with:
 
 ```
-conda config --add channels conda-forge
+conda config --add channels conda-forge/label/python_debug
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `libpython-static, python` can be installed with `conda`:
+Once the `conda-forge/label/python_debug` channel has been enabled, `libpython-static, python` can be installed with `conda`:
 
 ```
 conda install libpython-static python
@@ -163,26 +163,26 @@ mamba install libpython-static python
 It is possible to list all of the versions of `libpython-static` available on your platform with `conda`:
 
 ```
-conda search libpython-static --channel conda-forge
+conda search libpython-static --channel conda-forge/label/python_debug
 ```
 
 or with `mamba`:
 
 ```
-mamba search libpython-static --channel conda-forge
+mamba search libpython-static --channel conda-forge/label/python_debug
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search libpython-static --channel conda-forge
+mamba repoquery search libpython-static --channel conda-forge/label/python_debug
 
 # List packages depending on `libpython-static`:
-mamba repoquery whoneeds libpython-static --channel conda-forge
+mamba repoquery whoneeds libpython-static --channel conda-forge/label/python_debug
 
 # List dependencies of `libpython-static`:
-mamba repoquery depends libpython-static --channel conda-forge
+mamba repoquery depends libpython-static --channel conda-forge/label/python_debug
 ```
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,5 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
-  - template: ./.azure-pipelines/azure-pipelines-win.yml
   - template: ./.azure-pipelines/azure-pipelines-osx.yml
+  - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/build-locally.py
+++ b/build-locally.py
@@ -64,8 +64,9 @@ def verify_config(ns):
     elif ns.config.startswith("osx"):
         if "OSX_SDK_DIR" not in os.environ:
             raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=SDKs' "
-                "to download the SDK automatically to 'SDKs/MacOSX<ver>.sdk'. "
+                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+                "Note: OSX_SDK_DIR must be set to an absolute path. "
                 "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
             )
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,11 +1,6 @@
 build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: native}
-bot:
-  abi_migration_branches:
-  - 3.7
-  - 3.8
-  - 3.9
 azure:
   store_build_artifacts: true
 github:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -155,6 +155,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
+        - {{ stdlib('c') }}
         - {{ compiler('cxx') }}
         - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
         - {{ cdt('libx11-devel') }}  # [linux]
@@ -283,6 +284,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
+        - {{ stdlib('c') }}
         - {{ compiler('cxx') }}
 {% if from_source_control == 'yes' %}
         - git

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.11.8" %}
+{% set version = "3.11.9" %}
 {% set dev = "" %}
 {% set dev_ = "" %}
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
@@ -46,7 +46,7 @@ source:
 {% else %}
   - url: https://www.python.org/ftp/python/{{ version }}/Python-{{ version }}{{ dev }}.tar.xz
     # md5 from: https://www.python.org/downloads/release/python-{{ ver3nd }}/
-    md5: b353b8433e560e1af2b130f56dfbd973
+    md5: 22ea467e7d915477152e99d5da856ddc
 {% endif %}
     patches:
       - patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch


### PR DESCRIPTION
Freshly [released](https://discuss.python.org/t/python-3-11-9-is-available/50502), see [release notes](https://docs.python.org/release/3.11.9/whatsnew/changelog.html#python-3-11-9). It depends essentially on building against expat 2.6 (which we hadn't unvendored until 3.11) to address some CVEs, and thus, if we merge https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5640, we need to override this here in CBC. Seeing that this PR isn't merged yet, I haven't touched this here.

Finally, taking the opportunity to add stdlib here.