### PR TITLE
Build with libsqlite instead of sqlite

### DIFF
--- a/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'no'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 libuuid:
 - '2'
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - linux-64
 tk:

--- a/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'yes'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 libuuid:
 - '2'
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - linux-64
 tk:

--- a/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'no'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 libuuid:
 - '2'
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - linux-64
 tk:

--- a/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'yes'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 libuuid:
 - '2'
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - linux-64
 tk:

--- a/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'no'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 libuuid:
 - '2'
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - linux-aarch64
 tk:

--- a/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'yes'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 libuuid:
 - '2'
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - linux-aarch64
 tk:

--- a/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'no'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 libuuid:
 - '2'
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - linux-aarch64
 tk:

--- a/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'yes'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 libuuid:
 - '2'
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - linux-aarch64
 tk:

--- a/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'no'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 libuuid:
 - '2'
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'yes'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 libuuid:
 - '2'
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'no'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 libuuid:
 - '2'
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'yes'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 libuuid:
 - '2'
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'no'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - osx-64
 tk:

--- a/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'yes'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - osx-64
 tk:

--- a/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'no'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - osx-64
 tk:

--- a/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'yes'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - osx-64
 tk:

--- a/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'no'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 macos_machine:
 - arm64-apple-darwin20.0.0
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - osx-arm64
 tk:

--- a/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'yes'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 macos_machine:
 - arm64-apple-darwin20.0.0
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - osx-arm64
 tk:

--- a/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'no'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 macos_machine:
 - arm64-apple-darwin20.0.0
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - osx-arm64
 tk:

--- a/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -28,6 +28,10 @@ freethreading:
 - 'yes'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 macos_machine:
 - arm64-apple-darwin20.0.0
 ncurses:
@@ -42,8 +46,6 @@ python:
 - '3.13'
 readline:
 - '8'
-sqlite:
-- '3'
 target_platform:
 - osx-arm64
 tk:

--- a/.ci_support/win_64_freethreadingno.yaml
+++ b/.ci_support/win_64_freethreadingno.yaml
@@ -18,6 +18,10 @@ freethreading:
 - 'no'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 openssl:
 - '3'
 pin_run_as_build:
@@ -26,8 +30,6 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '3.13'
-sqlite:
-- '3'
 target_platform:
 - win-64
 tk:

--- a/.ci_support/win_64_freethreadingyes.yaml
+++ b/.ci_support/win_64_freethreadingyes.yaml
@@ -18,6 +18,10 @@ freethreading:
 - 'yes'
 libffi:
 - '3.4'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
 openssl:
 - '3'
 pin_run_as_build:
@@ -26,8 +30,6 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '3.13'
-sqlite:
-- '3'
 target_platform:
 - win-64
 tk:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 2 %}
+{% set build_number = 3 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}
@@ -163,7 +163,7 @@ outputs:
         - expat          # [build_platform != target_platform]
       host:
         - bzip2
-        - sqlite
+        - libsqlite
         - liblzma-devel
         - zlib
         - openssl


### PR DESCRIPTION
Edit: Dec 2024; Build Python 3.13 with libsqlite. Will backport once this is merged.

~Build with libsqlite and other fixes for python 3.12 to rebuild with our current CIs.~

~I'm getting testing errors on my CIs using the conda-forge docker images. Just want to test here.~
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
