### PR TITLE
Force siphash24 hash algorithm when cross-compiling

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -54,7 +54,7 @@ ulimit -n 1024
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line will be updated
 # automatically.
-/usr/bin/sudo -n yum install -y libX11 libxcb
+/usr/bin/sudo -n yum install -y libX11 libxcb libxau
 )
 
 # make the build number clobber

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -164,6 +164,7 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION}" == "1" ]]; then
   echo "ac_cv_file__dev_ptc=yes"        >> config.site
   echo "ac_cv_pthread=yes"              >> config.site
   echo "ac_cv_little_endian_double=yes" >> config.site
+  echo "ac_cv_aligned_required=no"      >> config.site
   if [[ ${target_platform} == osx-arm64 ]]; then
       echo "ac_cv_aligned_required=no" >> config.site
       echo "ac_cv_file__dev_ptc=no" >> config.site
@@ -248,10 +249,7 @@ _common_configure_args+=(--enable-loadable-sqlite-extensions)
 _common_configure_args+=(--with-tcltk-includes="-I${PREFIX}/include")
 _common_configure_args+=("--with-tcltk-libs=-L${PREFIX}/lib -ltcl8.6 -ltk8.6")
 _common_configure_args+=(--with-platlibdir=lib)
-
-if [[ "${CONDA_BUILD_CROSS_COMPILATION}" == "1" ]]; then
-  _common_configure_args+=(--with-hash-algorithm=siphash24)
-fi
+_common_configure_args+=(--with-hash-algorithm=siphash24)
 
 # Add more optimization flags for the static Python interpreter:
 declare -a PROFILE_TASK=()

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -249,6 +249,10 @@ _common_configure_args+=(--with-tcltk-includes="-I${PREFIX}/include")
 _common_configure_args+=("--with-tcltk-libs=-L${PREFIX}/lib -ltcl8.6 -ltk8.6")
 _common_configure_args+=(--with-platlibdir=lib)
 
+if [[ "${CONDA_BUILD_CROSS_COMPILATION}" == "1" ]]; then
+  _common_configure_args+=(--with-hash-algorithm=siphash24)
+fi
+
 # Add more optimization flags for the static Python interpreter:
 declare -a PROFILE_TASK=()
 if [[ ${_OPTIMIZED} == yes ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}


### PR DESCRIPTION
When cross-compiling, the hash function is forced to be FNV because the configure script defines `HAVE_ALIGNED_REQUIRED` which is then used by pyhash.h to change the default to FNV (see #718).

This PR fixes the issue by specifying siphash24 to the configure script when cross-compiling. With this PR, I now get:

```
$ python -c "import sys; print(sys.hash_info.algorithm)"
siphash24
```

instead of

```
$ python -c "import sys; print(sys.hash_info.algorithm)"
fnv
```

I'm not that familiar with the setup of this feedstock so I don't know if this is an appropriate solution or more of a sketch of a solution - any feedback / guidance is appreciated!

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] ~~Reset the build number to `0` (if the version changed)~~
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
