### PR TITLE
ensure run-export from xorg-libx11 gets ignored correctly everywhere

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -185,7 +185,11 @@ outputs:
         - python_abi {{ ver2 }}.* *_{{ abi_tag }}
     test:
       downstreams:
+{% if freethreading == "yes" %}
+        - cython >=3.1.0.a0
+{% else %}
         - cython
+{% endif %}
         - setuptools
       requires:
         - ripgrep

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}
@@ -88,7 +88,7 @@ outputs:
       # Copy rather than link.
       no_link:
         - DLLs/_ctypes.pyd  # [win]
-      ignore_run_exports_from:   # [unix]
+      ignore_run_exports_from:
         # C++ only installed so CXX is defined for distutils/sysconfig.
         - {{ compiler('cxx') }}  # [unix]
         # this is just to get the headers needed for tk.h, but is unused


### PR DESCRIPTION
Fixes #720

If this is acceptable, I can prepare the backports to maintenance branches.