### PR TITLE
Compile `sysconfig`'s data

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -19,31 +19,16 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    MINIFORGE_HOME: D:\Miniforge
     UPLOAD_TEMP: D:\\tmp
 
   steps:
-
-    - task: PythonScript@0
-      displayName: 'Download Miniforge'
-      inputs:
-        scriptSource: inline
-        script: |
-          import urllib.request
-          url = 'https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe'
-          path = r"$(Build.ArtifactStagingDirectory)/Miniforge.exe"
-          urllib.request.urlretrieve(url, path)
-
-    - script: |
-        start /wait "" %BUILD_ARTIFACTSTAGINGDIRECTORY%\Miniforge.exe /InstallationType=JustMe /RegisterPython=0 /S /D=C:\Miniforge
-      displayName: Install Miniforge
-
-    - powershell: Write-Host "##vso[task.prependpath]C:\Miniforge\Scripts"
-      displayName: Add conda to PATH
 
     - script: |
         call ".scripts\run_win_build.bat"
       displayName: Run Windows build
       env:
+        MINIFORGE_HOME: $(MINIFORGE_HOME)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure
@@ -56,6 +41,7 @@ jobs:
         FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
         STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
     - script: |
+        set MINIFORGE_HOME=$(MINIFORGE_HOME)
         set CI=azure
         set CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
         set FEEDSTOCK_NAME=$(build.Repository.Name)

--- a/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
@@ -55,7 +55,5 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
@@ -55,7 +55,5 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
@@ -55,7 +55,5 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
@@ -55,7 +55,5 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -15,7 +15,7 @@ c_stdlib_version:
 cdt_arch:
 - aarch64
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
@@ -59,7 +59,5 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -15,7 +15,7 @@ c_stdlib_version:
 cdt_arch:
 - aarch64
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
@@ -59,7 +59,5 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -15,7 +15,7 @@ c_stdlib_version:
 cdt_arch:
 - aarch64
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
@@ -59,7 +59,5 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -15,7 +15,7 @@ c_stdlib_version:
 cdt_arch:
 - aarch64
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
@@ -59,7 +59,5 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
@@ -53,7 +53,5 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
@@ -53,7 +53,5 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
@@ -53,7 +53,5 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cdt_name:
-- cos7
+- conda
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
@@ -53,7 +53,5 @@ zip_keys:
   - channel_targets
 - - c_compiler_version
   - cxx_compiler_version
-- - c_stdlib_version
-  - cdt_name
 zlib:
 - '1'

--- a/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -21,7 +21,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 expat:
 - '2'
 freethreading:

--- a/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -21,7 +21,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 expat:
 - '2'
 freethreading:

--- a/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -21,7 +21,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 expat:
 - '2'
 freethreading:

--- a/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -21,7 +21,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 expat:
 - '2'
 freethreading:

--- a/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -21,7 +21,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 expat:
 - '2'
 freethreading:

--- a/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -21,7 +21,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 expat:
 - '2'
 freethreading:

--- a/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -21,7 +21,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 expat:
 - '2'
 freethreading:

--- a/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '18'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -21,7 +21,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '18'
 expat:
 - '2'
 freethreading:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,12 +31,12 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
+mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
+echo > /opt/conda/conda-meta/history
+micromamba install --root-prefix ~/.conda --prefix /opt/conda \
+    --yes --override-channels --channel conda-forge --strict-channel-priority \
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
-
-mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
-mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -7,28 +7,39 @@ source .scripts/logging_utils.sh
 set -xe
 
 MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
+MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
 
-( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
-
-MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
-curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
-rm -rf ${MINIFORGE_HOME}
-bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
-
-( endgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
+( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
+MICROMAMBA_VERSION="1.5.10-0"
+if [[ "$(uname -m)" == "arm64" ]]; then
+  osx_arch="osx-arm64"
+else
+  osx_arch="osx-64"
+fi
+MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/micromamba-${osx_arch}"
+MAMBA_ROOT_PREFIX="${MINIFORGE_HOME}-micromamba-$(date +%s)"
+echo "Downloading micromamba ${MICROMAMBA_VERSION}"
+micromamba_exe="$(mktemp -d)/micromamba"
+curl -L -o "${micromamba_exe}" "${MICROMAMBA_URL}"
+chmod +x "${micromamba_exe}"
+echo "Creating environment"
+"${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
+  --channel conda-forge \
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
+mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
+echo "Cleaning up micromamba"
+rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
+( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
-
-source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
+echo "Activating environment"
+source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
 conda activate base
 export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
-mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
-mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+
 
 
 

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -3,29 +3,49 @@
 :: changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 :: benefit from the improvement.
 
-:: Note: we assume a Miniforge installation is available
-
 :: INPUTS (required environment variables)
 :: CONFIG: name of the .ci_support/*.yaml file for this job
 :: CI: azure, github_actions, or unset
+:: MINIFORGE_HOME: where to install the base conda environment
 :: UPLOAD_PACKAGES: true or false
 :: UPLOAD_ON_BRANCH: true or false
 
 setlocal enableextensions enabledelayedexpansion
 
+FOR %%A IN ("%~dp0.") DO SET "REPO_ROOT=%%~dpA"
+if "%MINIFORGE_HOME%"=="" set "MINIFORGE_HOME=%USERPROFILE%\Miniforge3"
+:: Remove trailing backslash, if present
+if "%MINIFORGE_HOME:~-1%"=="\" set "MINIFORGE_HOME=%MINIFORGE_HOME:~0,-1%"
+call :start_group "Provisioning base env with micromamba"
+set "MAMBA_ROOT_PREFIX=%MINIFORGE_HOME%-micromamba-%RANDOM%"
+set "MICROMAMBA_VERSION=1.5.10-0"
+set "MICROMAMBA_URL=https://github.com/mamba-org/micromamba-releases/releases/download/%MICROMAMBA_VERSION%/micromamba-win-64"
+set "MICROMAMBA_TMPDIR=%TMP%\micromamba-%RANDOM%"
+set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
+
+echo Downloading micromamba %MICROMAMBA_VERSION%
+if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
+certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+if !errorlevel! neq 0 exit /b !errorlevel!
+
+echo Creating environment
+call "%MICROMAMBA_EXE%" create --yes --root-prefix "%MAMBA_ROOT_PREFIX%" --prefix "%MINIFORGE_HOME%" ^
+    --channel conda-forge ^
+    pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+if !errorlevel! neq 0 exit /b !errorlevel!
+echo Removing %MAMBA_ROOT_PREFIX%
+del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
+del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+
 call :start_group "Configuring conda"
 
 :: Activate the base conda environment
-call activate base
+echo Activating environment
+call "%MINIFORGE_HOME%\Scripts\activate.bat"
 :: Configure the solver
 set "CONDA_SOLVER=libmamba"
 if !errorlevel! neq 0 exit /b !errorlevel!
 set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
-
-:: Provision the necessary dependencies to build the recipe later
-echo Installing dependencies
-mamba.exe install pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" -c conda-forge --strict-channel-priority --yes
-if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration
 echo Setting up configuration

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
           echo "##vso[task.setvariable variable=log]$git_log"
         displayName: Obtain commit message
       - bash: echo "##vso[task.setvariable variable=RET]false"
-        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+        condition: and(eq(variables['Build.Reason'], 'PullRequest'), or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]')))
         displayName: Skip build?
       - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
         name: result

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -185,6 +185,10 @@ if "%EXE_T%" neq "" copy %PREFIX%\python%EXE_T%.exe %PREFIX%\python.exe
 %PREFIX%\python.exe -Wi %PREFIX%\Lib\compileall.py -f -q -x "bad_coding|badsyntax|py2_" %PREFIX%\Lib
 if errorlevel 1 exit 1
 
+:: Ensure `sysconfig`'s data is also compiled
+%PREFIX%\python.exe -c "import pprint, sysconfig; pprint(sysconfig.get_config_vars())"
+if %errorlevel% neq 1 exit /b 1
+
 :: Ensure that scripts are generated
 :: https://github.com/conda-forge/python-feedstock/issues/384
 %PREFIX%\python.exe %RECIPE_DIR%\fix_staged_scripts.py

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -532,7 +532,10 @@ if [[ ${HOST} =~ .*linux.* ]]; then
   echo "See: https://github.com/conda/conda/issues/6030 for more information."                                   >> ${PREFIX}/shared/python_compiler_compat/README
 fi
 
+# Compile all Python files
+# Ensure `sysconfig`'s data is also compiled
 python -c "import compileall,os;compileall.compile_dir(os.environ['PREFIX'])"
+python -c "import pprint, sysconfig; pprint(sysconfig.get_config_vars())"
 rm ${PREFIX}/lib/libpython${VERABI}.a
 
 if [[ ${PY_INTERP_DEBUG} == yes ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}


### PR DESCRIPTION
It appears `sysconfig`'s data doesn't get compiled until install time, which results in a file modification after installation. This can throw up red flags in certain install environments and when using `conda doctor`. To address this, `import sysconfig` and run `sysconfig.get_config_vars()`, which loads the data file as a `dict`. This should compile the data file.

Also `pprint` the data for additional debug information/validation.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/python-feedstock/issues/741

<!--
Please add any other relevant info below:
-->
