### PR TITLE
Remove pid_t definition in windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 4 %}
+{% set build_number = 5 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}

--- a/recipe/patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
+++ b/recipe/patches/0001-Win32-Change-FD_SETSIZE-from-512-to-2048.patch
@@ -1,7 +1,7 @@
-From ab2a0ef0f9757900f002ae5cfb2732da07cdb730 Mon Sep 17 00:00:00 2001
+From dac2f3b33cbb97245660be0269f2dd015b7b8d06 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:53:55 +0100
-Subject: [PATCH 01/23] Win32: Change FD_SETSIZE from 512 to 2048
+Subject: [PATCH 01/24] Win32: Change FD_SETSIZE from 512 to 2048
 
 https://github.com/ContinuumIO/anaconda-issues/issues/1241
 ---

--- a/recipe/patches/0002-Win32-Do-not-download-externals.patch
+++ b/recipe/patches/0002-Win32-Do-not-download-externals.patch
@@ -1,7 +1,7 @@
-From fbe15c02d7edea0de89e2c4ef2ccb2f14582a515 Mon Sep 17 00:00:00 2001
+From 7158d078f72cd29ad01301f762c4b3aaaf3a2d51 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Thu, 7 Sep 2017 11:35:47 +0100
-Subject: [PATCH 02/23] Win32: Do not download externals
+Subject: [PATCH 02/24] Win32: Do not download externals
 
 ---
  PCbuild/build.bat | 4 ++--

--- a/recipe/patches/0003-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
+++ b/recipe/patches/0003-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -1,7 +1,7 @@
-From cc490a55e74e511957be1fb3b2468cc5d1d1162b Mon Sep 17 00:00:00 2001
+From df36d349debe414f5b9d7d0ba937f5faff3ac486 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 5 Dec 2017 22:47:59 +0000
-Subject: [PATCH 03/23] Fix find_library so that it looks in sys.prefix/lib
+Subject: [PATCH 03/24] Fix find_library so that it looks in sys.prefix/lib
  first
 
 ---

--- a/recipe/patches/0004-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
+++ b/recipe/patches/0004-Disable-registry-lookup-unless-CONDA_PY_ALLOW_REG_PA.patch
@@ -1,7 +1,7 @@
-From 418e53e98a25cbc629afcfb0b441c218ea1ef51e Mon Sep 17 00:00:00 2001
+From 6121895c5d1b342b37cc0873176d047347189cf7 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sat, 27 Oct 2018 18:48:30 +0100
-Subject: [PATCH 04/23] Disable registry lookup unless CONDA_PY_ALLOW_REG_PATHS
+Subject: [PATCH 04/24] Disable registry lookup unless CONDA_PY_ALLOW_REG_PATHS
  is not 0
 
 Co-authored-by: Isuru Fernando<isuruf@gmail.com>

--- a/recipe/patches/0005-Unvendor-openssl.patch
+++ b/recipe/patches/0005-Unvendor-openssl.patch
@@ -1,7 +1,7 @@
-From 71bf198e09615b89d2bd8367839b0ea8329de93c Mon Sep 17 00:00:00 2001
+From ab54f63b3341cfe20d64bb536c63e1fcf14e619b Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sat, 24 Nov 2018 20:38:02 -0600
-Subject: [PATCH 05/23] Unvendor openssl
+Subject: [PATCH 05/24] Unvendor openssl
 
 Co-authored-by: Isuru Fernando <isuruf@gmail.com>
 ---

--- a/recipe/patches/0006-Unvendor-sqlite3.patch
+++ b/recipe/patches/0006-Unvendor-sqlite3.patch
@@ -1,7 +1,7 @@
-From 26efebf5c402db2622e2baf998fa5ef854eefc98 Mon Sep 17 00:00:00 2001
+From 57d675669a6ebb5fdc5d329332993b018f706108 Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Tue, 5 Oct 2021 12:42:06 -0700
-Subject: [PATCH 06/23] Unvendor sqlite3
+Subject: [PATCH 06/24] Unvendor sqlite3
 
 ---
  PCbuild/_sqlite3.vcxproj | 11 +++++------

--- a/recipe/patches/0007-Add-CondaEcosystemModifyDllSearchPath.patch
+++ b/recipe/patches/0007-Add-CondaEcosystemModifyDllSearchPath.patch
@@ -1,7 +1,7 @@
-From 40f67f167b72114fefda0b783b2d22e6ca439ecf Mon Sep 17 00:00:00 2001
+From 655f497ed88c7bb9288bbaba0a6da899c1de8df6 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 24 Dec 2019 18:37:17 +0100
-Subject: [PATCH 07/23] Add CondaEcosystemModifyDllSearchPath()
+Subject: [PATCH 07/24] Add CondaEcosystemModifyDllSearchPath()
 
   The python interpreter is modifed so that it works as if the python interpreter
   was called with the following conda directories.

--- a/recipe/patches/0008-Doing-d1trimfile.patch
+++ b/recipe/patches/0008-Doing-d1trimfile.patch
@@ -1,7 +1,7 @@
-From 6040773fedb0a28fd98a5a06bdf70886999b89e7 Mon Sep 17 00:00:00 2001
+From 69e659ffc9565bc3a81d01f66aa021fcfaa80e49 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 31 Dec 2019 21:47:47 +0100
-Subject: [PATCH 08/23] Doing d1trimfile
+Subject: [PATCH 08/24] Doing d1trimfile
 
 ---
  PCbuild/_asyncio.vcxproj            | 20 ++++++++++++++++++++

--- a/recipe/patches/0009-cross-compile-darwin.patch
+++ b/recipe/patches/0009-cross-compile-darwin.patch
@@ -1,7 +1,7 @@
-From 63a8b3e83c26cd82544076565db9c97ce7d0fa9d Mon Sep 17 00:00:00 2001
+From 12fa37b4a106af3e57d87f7cfda2e5cd1f41b502 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Fri, 2 Oct 2020 00:03:12 +0200
-Subject: [PATCH 09/23] cross compile darwin
+Subject: [PATCH 09/24] cross compile darwin
 
 By Isuru Fernando.
 ---

--- a/recipe/patches/0010-Fix-TZPATH-on-windows.patch
+++ b/recipe/patches/0010-Fix-TZPATH-on-windows.patch
@@ -1,7 +1,7 @@
-From 9832cf5b672b9727b8dd53f5bc3102b5392b47eb Mon Sep 17 00:00:00 2001
+From 68f86b5cd9c77aaccdf285e4d820060c3bd5d0b3 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 7 Oct 2020 10:08:30 -0500
-Subject: [PATCH 10/23] Fix TZPATH on windows
+Subject: [PATCH 10/24] Fix TZPATH on windows
 
 ---
  Lib/sysconfig/__init__.py | 1 +

--- a/recipe/patches/0011-Make-dyld-search-work-with-SYSTEM_VERSION_COMPAT-1.patch
+++ b/recipe/patches/0011-Make-dyld-search-work-with-SYSTEM_VERSION_COMPAT-1.patch
@@ -1,7 +1,7 @@
-From 36eff8fef320b46a7ba58eadc7f5373ba2fd1660 Mon Sep 17 00:00:00 2001
+From 116ad2f8e5e26cd72d4d67652c1fe79b79b01092 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 25 Jan 2021 03:28:08 -0600
-Subject: [PATCH 11/23] Make dyld search work with SYSTEM_VERSION_COMPAT=1
+Subject: [PATCH 11/24] Make dyld search work with SYSTEM_VERSION_COMPAT=1
 
 In macOS Big Sur, if the executable was compiled with `MACOSX_DEPLOYMENT_TARGET=10.15`
 or below, then SYSTEM_VERSION_COMPAT=1 is the default which means that Big Sur

--- a/recipe/patches/0012-Unvendor-bzip2.patch
+++ b/recipe/patches/0012-Unvendor-bzip2.patch
@@ -1,7 +1,7 @@
-From 7a330247c92583afa0a497cb99d0d4b899999544 Mon Sep 17 00:00:00 2001
+From d8c238906a7544c841e3d422b44f1b3157d02e34 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 02:56:27 -0700
-Subject: [PATCH 12/23] Unvendor bzip2
+Subject: [PATCH 12/24] Unvendor bzip2
 
 ---
  PCbuild/_bz2.vcxproj         | 15 +++++----------

--- a/recipe/patches/0013-Unvendor-libffi.patch
+++ b/recipe/patches/0013-Unvendor-libffi.patch
@@ -1,7 +1,7 @@
-From eca87c80f78182f5fdb1a1ae520ede412545eb8b Mon Sep 17 00:00:00 2001
+From 1ae3603a02b8d478732915257a5827926e8a0974 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 16 Aug 2021 03:07:40 -0700
-Subject: [PATCH 13/23] Unvendor libffi
+Subject: [PATCH 13/24] Unvendor libffi
 
 ---
  PCbuild/libffi.props | 17 ++++-------------

--- a/recipe/patches/0014-Unvendor-tcltk.patch
+++ b/recipe/patches/0014-Unvendor-tcltk.patch
@@ -1,7 +1,7 @@
-From 5daa08d74f165cad5c86a6a8cfdb5c1c00c9a544 Mon Sep 17 00:00:00 2001
+From c82917b47035e936b2b9ebf35fdc54593e78dbf3 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Fri, 20 Aug 2021 10:23:51 -0700
-Subject: [PATCH 14/23] Unvendor tcltk
+Subject: [PATCH 14/24] Unvendor tcltk
 
 ---
  PCbuild/_tkinter.vcxproj |  6 ------

--- a/recipe/patches/0015-unvendor-xz.patch
+++ b/recipe/patches/0015-unvendor-xz.patch
@@ -1,14 +1,14 @@
-From afab00e7f9e99c1e438c407c7b3f6eaa78886d5a Mon Sep 17 00:00:00 2001
+From 5fe6c7efee65427246e795ba2b936ea104365057 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Sat, 25 Sep 2021 10:07:05 -0700
-Subject: [PATCH 15/23] unvendor xz
+Subject: [PATCH 15/24] unvendor xz
 
 ---
  PCbuild/_lzma.vcxproj | 10 +++-------
  1 file changed, 3 insertions(+), 7 deletions(-)
 
 diff --git a/PCbuild/_lzma.vcxproj b/PCbuild/_lzma.vcxproj
-index 321f41d8d27..bd7d6c64b10 100644
+index 321f41d8d27..6811fd1709e 100644
 --- a/PCbuild/_lzma.vcxproj
 +++ b/PCbuild/_lzma.vcxproj
 @@ -93,15 +93,15 @@

--- a/recipe/patches/0016-unvendor-zlib.patch
+++ b/recipe/patches/0016-unvendor-zlib.patch
@@ -1,7 +1,7 @@
-From e40b831fd07ec6a12d661c829dd5615bd1e4729f Mon Sep 17 00:00:00 2001
+From 177810b9912a9f10c2cb4c1682badd7ebdc15234 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 29 Sep 2021 15:21:55 -0700
-Subject: [PATCH 16/23] unvendor zlib
+Subject: [PATCH 16/24] unvendor zlib
 
 ---
  PCbuild/pythoncore.vcxproj         | 33 ++-------------

--- a/recipe/patches/0017-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
+++ b/recipe/patches/0017-Do-not-pass-g-to-GCC-when-not-Py_DEBUG.patch
@@ -1,7 +1,7 @@
-From 17f3753e62d6defc46c73f405878c3d7abd25896 Mon Sep 17 00:00:00 2001
+From 00400877a37f4f611379147bf1f01a500495f4e0 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 16 Aug 2017 11:45:28 +0100
-Subject: [PATCH 17/23] Do not pass -g to GCC when not Py_DEBUG
+Subject: [PATCH 17/24] Do not pass -g to GCC when not Py_DEBUG
 
 This bloats our exe and our modules a lot.
 ---

--- a/recipe/patches/0018-Unvendor-expat.patch
+++ b/recipe/patches/0018-Unvendor-expat.patch
@@ -1,7 +1,7 @@
-From 00b77e387f567a97250cedbf054f1f64a1f54f51 Mon Sep 17 00:00:00 2001
+From 6b6b59052caff823e0404b44cf3962467576bba3 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 29 Mar 2023 23:07:10 -0500
-Subject: [PATCH 18/23] Unvendor expat
+Subject: [PATCH 18/24] Unvendor expat
 
 ---
  PCbuild/_elementtree.vcxproj         | 25 ++----------

--- a/recipe/patches/0019-Remove-unused-readelf.patch
+++ b/recipe/patches/0019-Remove-unused-readelf.patch
@@ -1,7 +1,7 @@
-From aa8ba18bb2b72744bc245c2afb8aa4519cae5c19 Mon Sep 17 00:00:00 2001
+From 97b20be9d1f08b21255f59e72eaceb2df7256d36 Mon Sep 17 00:00:00 2001
 From: Charles Bousseau <cbousseau@anaconda.com>
 Date: Thu, 25 May 2023 17:56:53 -0400
-Subject: [PATCH 19/23] Remove unused readelf
+Subject: [PATCH 19/24] Remove unused readelf
 
 readelf has been dropped.
 .. date: 2022-11-02-10-56-40

--- a/recipe/patches/0020-Don-t-checksharedmods-if-cross-compiling.patch
+++ b/recipe/patches/0020-Don-t-checksharedmods-if-cross-compiling.patch
@@ -1,7 +1,7 @@
-From 534eb93832b4a219bb2b4b940989c3e3809be802 Mon Sep 17 00:00:00 2001
+From cbc6af129157df051115bf5d8f3097d0a01ef8d7 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Fri, 1 Sep 2023 23:32:14 +0200
-Subject: [PATCH 20/23] Don't checksharedmods if cross-compiling
+Subject: [PATCH 20/24] Don't checksharedmods if cross-compiling
 
 ---
  Makefile.pre.in |  2 +-

--- a/recipe/patches/0021-Override-configure-LIBFFI.patch
+++ b/recipe/patches/0021-Override-configure-LIBFFI.patch
@@ -1,7 +1,7 @@
-From 36d02ddc0beda1b2a326a3559715cc90ca7f1836 Mon Sep 17 00:00:00 2001
+From b6bb9f0ab8ce0938f64a50d9c402b30f2a464c8c Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Tue, 5 Sep 2023 21:51:31 +0200
-Subject: [PATCH 21/23] Override configure LIBFFI
+Subject: [PATCH 21/24] Override configure LIBFFI
 
 ---
  configure | 2 +-

--- a/recipe/patches/0022-Unvendor-libmpdec.patch
+++ b/recipe/patches/0022-Unvendor-libmpdec.patch
@@ -1,7 +1,7 @@
-From ec5a566e422edc48789bc49bb998263f77253587 Mon Sep 17 00:00:00 2001
+From 2fdc8320aa541722ab3902ec2d33e4eb31e97e91 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Fri, 16 Aug 2024 21:34:43 -0500
-Subject: [PATCH 22/23] Unvendor libmpdec
+Subject: [PATCH 22/24] Unvendor libmpdec
 
 ---
  PCbuild/_decimal.vcxproj | 50 +++++-----------------------------------

--- a/recipe/patches/0023-Brand-conda-forge.patch
+++ b/recipe/patches/0023-Brand-conda-forge.patch
@@ -1,7 +1,7 @@
-From 58b2f9aad3ae81f188d973a0511faffcaae5ee77 Mon Sep 17 00:00:00 2001
+From 6007d7de00fab5c2c16e2fd5dfe4165f88c3c5fd Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Wed, 28 Aug 2024 11:12:22 -0500
-Subject: [PATCH 23/23] Brand conda-forge
+Subject: [PATCH 23/24] Brand conda-forge
 
 ---
  Lib/platform.py     | 1 +

--- a/recipe/patches/0024-Do-not-define-pid_t-as-it-might-conflict-with-the-ac.patch
+++ b/recipe/patches/0024-Do-not-define-pid_t-as-it-might-conflict-with-the-ac.patch
@@ -1,0 +1,23 @@
+From 4fb09595193ab713507e90ecda0d85e5378f9ca0 Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Sun, 12 Jan 2025 10:37:29 +0530
+Subject: [PATCH 24/24] Do not define pid_t as it might conflict with the
+ actual definition
+
+---
+ PC/pyconfig.h.in | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/PC/pyconfig.h.in b/PC/pyconfig.h.in
+index 424421f6ff1..2c1b5a5b834 100644
+--- a/PC/pyconfig.h.in
++++ b/PC/pyconfig.h.in
+@@ -230,8 +230,6 @@ typedef _W64 int Py_ssize_t;
+ #endif
+ #endif /* MS_WIN32 && !MS_WIN64 */
+ 
+-typedef int pid_t;
+-
+ /* define some ANSI types that are not defined in earlier Win headers */
+ #if _MSC_VER >= 1200
+ /* This file only exists in VC 6.0 or higher */


### PR DESCRIPTION
It's not used at all and might conflict with winpthreads-devel definition