### PR TITLE
[3.10] Use older libffi as new is not working with 3.10 on windows

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libffi:
-- '3.4'
 liblzma_devel:
 - '5'
 libuuid:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libffi:
-- '3.4'
 liblzma_devel:
 - '5'
 libuuid:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-libffi:
-- '3.4'
 liblzma_devel:
 - '5'
 libuuid:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -20,8 +20,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
-libffi:
-- '3.4'
 liblzma_devel:
 - '5'
 macos_machine:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -20,8 +20,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
-libffi:
-- '3.4'
 liblzma_devel:
 - '5'
 macos_machine:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -10,8 +10,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
-libffi:
-- '3.4'
 liblzma_devel:
 - '5'
 openssl:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-cpython-green.svg)](https://anaconda.org/conda-forge/cpython) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cpython.svg)](https://anaconda.org/conda-forge/cpython) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cpython.svg)](https://anaconda.org/conda-forge/cpython) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cpython.svg)](https://anaconda.org/conda-forge/cpython) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-cpython--gil-green.svg)](https://anaconda.org/conda-forge/cpython-gil) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cpython-gil.svg)](https://anaconda.org/conda-forge/cpython-gil) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cpython-gil.svg)](https://anaconda.org/conda-forge/cpython-gil) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cpython-gil.svg)](https://anaconda.org/conda-forge/cpython-gil) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libpython--static-green.svg)](https://anaconda.org/conda-forge/libpython-static) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libpython-static.svg)](https://anaconda.org/conda-forge/libpython-static) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libpython-static.svg)](https://anaconda.org/conda-forge/libpython-static) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libpython-static.svg)](https://anaconda.org/conda-forge/libpython-static) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-python-green.svg)](https://anaconda.org/conda-forge/python) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/python.svg)](https://anaconda.org/conda-forge/python) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/python.svg)](https://anaconda.org/conda-forge/python) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/python.svg)](https://anaconda.org/conda-forge/python) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-python--gil-green.svg)](https://anaconda.org/conda-forge/python-gil) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/python-gil.svg)](https://anaconda.org/conda-forge/python-gil) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/python-gil.svg)](https://anaconda.org/conda-forge/python-gil) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/python-gil.svg)](https://anaconda.org/conda-forge/python-gil) |
 
 Installing python
 =================
@@ -108,16 +108,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `cpython, cpython-gil, libpython-static, python` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `cpython, libpython-static, python, python-gil` can be installed with `conda`:
 
 ```
-conda install cpython cpython-gil libpython-static python
+conda install cpython libpython-static python python-gil
 ```
 
 or with `mamba`:
 
 ```
-mamba install cpython cpython-gil libpython-static python
+mamba install cpython libpython-static python python-gil
 ```
 
 It is possible to list all of the versions of `cpython` available on your platform with `conda`:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,6 +2,8 @@ python:
   - 3.10
 python_impl:
   - cpython
+is_python_min:
+  - no
 numpy:
   - 1.16
 MACOSX_SDK_VERSION:            # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}
@@ -181,7 +181,7 @@ outputs:
         - xorg-libx11
         - xorg-xorgproto
         - ncurses  # [unix]
-        - libffi
+        - libffi <3.4.6
         - ld_impl_{{ target_platform }} >=2.36.1  # [linux]
         - libnsl  # [linux]
         - libuuid  # [linux]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


While working on #776 I discovered that the windows build for 3.10 (and 3.9) does not work on windows anymore.

I did not really find the root cause, but I checked old build logs from CI and the only major diff I could find was the libffi version. So I tried downgrading the libffi version and this apparently fixes the build.

Open question is:
Should the Linux build also downgrade or should be different versions of libffi be used per OS?

Also the other question would be what is the proper fix. I could not yet identify the exact PR in the Python repo that would fix this.