### PR TITLE
Fix clash between folders in lib and usable libraries

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}

--- a/recipe/patches/0003-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
+++ b/recipe/patches/0003-Fix-find_library-so-that-it-looks-in-sys.prefix-lib-.patch
@@ -1,4 +1,4 @@
-From 2e9e95c2e3aa8d212a302de52f19d129c5068d57 Mon Sep 17 00:00:00 2001
+From 72e412d8563cb7e0844e814b16d6fd9aa83d476b Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Tue, 5 Dec 2017 22:47:59 +0000
 Subject: [PATCH 03/26] Fix find_library so that it looks in sys.prefix/lib
@@ -25,7 +25,7 @@ index 583c47daff3..ab9b01c87e2 100644
          yield os.path.join(executable_path, name[len('@executable_path/'):])
  
 diff --git a/Lib/ctypes/util.py b/Lib/ctypes/util.py
-index 378f12167c6..bf45580ab9f 100644
+index 378f12167c6..a0e4060721a 100644
 --- a/Lib/ctypes/util.py
 +++ b/Lib/ctypes/util.py
 @@ -129,7 +129,8 @@ def dllist():
@@ -47,7 +47,7 @@ index 378f12167c6..bf45580ab9f 100644
 +                return None
 +            for fullname in (name, "lib%s.so" % (name)):
 +                path = os.path.join(sys.prefix, 'lib', fullname)
-+                if os.path.exists(path):
++                if os.path.exists(path) and not os.path.isdir(path):
 +                    return path
 +            return None
 +


### PR DESCRIPTION
xref: https://github.com/conda-forge/rdma-core-feedstock/issues/36

Backports:

- [ ] 3.13  #845 
- [ ] 3.12  #846
- [ ] 3.11  #848
- [ ] 3.10  #847

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
