### PR TITLE
Support linux-riscv64 platform

### DIFF
--- a/.ci_support/linux_riscv64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/linux_riscv64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -1,0 +1,59 @@
+build_type:
+- debug
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '15'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.39'
+channel_sources:
+- conda-forge/label/python_rc,conda-forge
+channel_targets:
+- conda-forge python_debug
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '15'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
+expat:
+- '2'
+freethreading:
+- 'no'
+libffi:
+- '3.7'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
+libuuid:
+- '2'
+ncurses:
+- '6'
+openssl:
+- '3.5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.14'
+readline:
+- '8'
+target_platform:
+- linux-riscv64
+tk:
+- '8.6'
+zip_keys:
+- - build_type
+  - channel_targets
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1'
+zstd:
+- '1.5'

--- a/.ci_support/linux_riscv64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/linux_riscv64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -1,0 +1,59 @@
+build_type:
+- debug
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '15'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.39'
+channel_sources:
+- conda-forge/label/python_rc,conda-forge
+channel_targets:
+- conda-forge python_debug
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '15'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
+expat:
+- '2'
+freethreading:
+- 'yes'
+libffi:
+- '3.7'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
+libuuid:
+- '2'
+ncurses:
+- '6'
+openssl:
+- '3.5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.14'
+readline:
+- '8'
+target_platform:
+- linux-riscv64
+tk:
+- '8.6'
+zip_keys:
+- - build_type
+  - channel_targets
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1'
+zstd:
+- '1.5'

--- a/.ci_support/linux_riscv64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/linux_riscv64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -1,0 +1,59 @@
+build_type:
+- release
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '15'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.39'
+channel_sources:
+- conda-forge/label/python_rc,conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '15'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
+expat:
+- '2'
+freethreading:
+- 'no'
+libffi:
+- '3.7'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
+libuuid:
+- '2'
+ncurses:
+- '6'
+openssl:
+- '3.5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.14'
+readline:
+- '8'
+target_platform:
+- linux-riscv64
+tk:
+- '8.6'
+zip_keys:
+- - build_type
+  - channel_targets
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1'
+zstd:
+- '1.5'

--- a/.ci_support/linux_riscv64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/linux_riscv64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -1,0 +1,59 @@
+build_type:
+- release
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '15'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.39'
+channel_sources:
+- conda-forge/label/python_rc,conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '15'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
+expat:
+- '2'
+freethreading:
+- 'yes'
+libffi:
+- '3.7'
+liblzma_devel:
+- '5'
+libsqlite:
+- '3'
+libuuid:
+- '2'
+ncurses:
+- '6'
+openssl:
+- '3.5'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.14'
+readline:
+- '8'
+target_platform:
+- linux-riscv64
+tk:
+- '8.6'
+zip_keys:
+- - build_type
+  - channel_targets
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1'
+zstd:
+- '1.5'

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -166,6 +166,54 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
+          - CONFIG: linux_riscv64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
+          - CONFIG: linux_riscv64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
+          - CONFIG: linux_riscv64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
+          - CONFIG: linux_riscv64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
           - CONFIG: win_64_freethreadingno
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,6 +6,7 @@ bot:
   - '3.13'
 build_platform:
   linux_ppc64le: linux_64
+  linux_riscv64: linux_64
   win_arm64: win_64
 conda_build:
   pkg_format: '2'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -172,7 +172,7 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION}" == "1" ]]; then
   echo "ac_cv_file__dev_ptc=no"         >> config.site
   echo "ac_cv_pthread=yes"              >> config.site
   echo "ac_cv_little_endian_double=yes" >> config.site
-  if [[ "${target_platform}" == "osx-arm64" || "${target_platform}" == "linux-ppc64le" || "${target_platform}" == "linux-aarch64" ]]; then
+  if [[ "${target_platform}" == "osx-arm64" || "${target_platform}" == "linux-ppc64le" || "${target_platform}" == "linux-aarch64"  || "${target_platform}" == "linux-riscv64" ]]; then
       echo "ac_cv_aligned_required=no" >> config.site
       echo "ac_cv_pthread_is_default=yes" >> config.site
       echo "ac_cv_working_tzset=yes" >> config.site


### PR DESCRIPTION
Manually because the bot broke a dependency cycle by just marking stuff as done.

~Based on #894 for convenience, but can be split if necessary.~