### PR TITLE
[3.11] build: enable aarch64 optimizations

### DIFF
--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -48,9 +48,6 @@ if [[ ${PY_INTERP_DEBUG} == yes ]]; then
 fi
 
 # Since these take very long to build in our emulated ci, disable for now
-if [[ ${target_platform} == linux-aarch64 ]]; then
-  _OPTIMIZED=no
-fi
 if [[ ${target_platform} == linux-ppc64le ]]; then
   _OPTIMIZED=no
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}


### PR DESCRIPTION
## Summary

Linux AArch64 builds now run natively, but the Python 3.11 branch still
inherits the historical emulated-CI override that disables its existing
LTO and PGO path.

## Changes

- Remove only the Linux AArch64 `_OPTIMIZED=no` override
- Keep the cross-built PPC64LE override unchanged
- Bump the unchanged-version recipe build number

## Test Plan

- Verified the candidate retains `--with-lto`, `--enable-optimizations`,
  `profile-opt`, and `PROFILE_TASK="-m test --pgo"`
- Verified the branch diff contains only `recipe/build_base.sh` and
  `recipe/meta.yaml`
- Use the native Linux AArch64 GitHub Actions job for build validation

## Known Concern

Native AArch64 Python rebuilds have an open downstream cross-build
compatibility issue in #880. This draft does not alter that sysconfig/linker
behavior.

Part of #903