### PR TITLE
actually move python*.dll to libpython on windows

### DIFF
--- a/recipe/install_base.bat
+++ b/recipe/install_base.bat
@@ -51,7 +51,7 @@ if "%PY_FREETHREADING%" == "yes" (
 )
 
 :: Populate the root package directory
-for %%x in (python%VERNODOTS%%THREAD%%_D%.dll python3%THREAD%%_D%.dll python%EXE_T%%_D%.exe pythonw%EXE_T%%_D%.exe) do (
+for %%x in (python%EXE_T%%_D%.exe pythonw%EXE_T%%_D%.exe) do (
   if exist %SRC_DIR%\PCbuild\%HOST_DIR%\%%x (
     copy /Y %SRC_DIR%\PCbuild\%HOST_DIR%\%%x %PREFIX%
   ) else (

--- a/recipe/install_shared.bat
+++ b/recipe/install_shared.bat
@@ -1,0 +1,37 @@
+setlocal EnableDelayedExpansion
+echo on
+
+if "%target_platform%"=="win-64" (
+   set HOST_DIR=amd64
+)
+if "%target_platform%"=="win-32" (
+   set HOST_DIR=win32
+)
+if "%target_platform%"=="win-arm64" (
+   set HOST_DIR=arm64
+)
+
+for /F "tokens=1,2 delims=." %%i in ("%PKG_VERSION%") do (
+  set "VERNODOTS=%%i%%j"
+)
+
+if "%PY_INTERP_DEBUG%"=="yes" (
+  set _D=_d
+) else (
+  set _D=
+)
+
+if "%PY_FREETHREADING%" == "yes" (
+  set "THREAD=t"
+) else (
+  set "THREAD="
+)
+
+:: move python*.dll
+for %%x in (python%VERNODOTS%%THREAD%%_D%.dll python3%THREAD%%_D%.dll) do (
+  if exist %SRC_DIR%\PCbuild\%HOST_DIR%\%%x (
+    copy /Y %SRC_DIR%\PCbuild\%HOST_DIR%\%%x %PREFIX%
+  ) else (
+    echo "WARNING :: %SRC_DIR%\PCbuild\%HOST_DIR%\%%x does not exist"
+  )
+)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -270,6 +270,8 @@ outputs:
       commands:
         - echo on  # [win]
         - set  # [win]
+        # ensure we don't pick up python from the image by accident
+        - rmdir /s /q C:\hostedtoolcache\windows\Python  # [win]
         - python -V
         - python3 -V            # [not win]
         - pydoc -h

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -265,6 +265,7 @@ outputs:
       files:
         - tests/cmake/*
         - tests/cython/*
+        - tests/prefix-replacement/*
         - run_test.py
       commands:
         - echo on  # [win]
@@ -308,7 +309,11 @@ outputs:
         - if not exist %PREFIX%\\Scripts\\pydoc.exe exit 1  # [win]
         - if not exist %PREFIX%\\include\\pyconfig.h exit 1  # [win]
         - pushd tests
+        - pushd prefix-replacement  # [unix]
+        - bash build-and-test.sh    # [unix]
+        - popd                      # [unix]
         - pushd cmake
+        - cmake -GNinja {{ cmake_test_args }} -DPY_VER={{ version }} -DEXTRA_COMPONENTS="Development.Embed" {{ cmake_debug }} .
         - cmake -GNinja {{ cmake_test_args }} -DPY_VER={{ version }} -DEXTRA_COMPONENTS="Development.Module" {{ cmake_debug }} .
         - popd
         - popd
@@ -338,20 +343,6 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
     test:
-      files:
-        - tests/cmake/*
-        - tests/prefix-replacement/*
-      requires:
-        - {{ stdlib('c') }}
-        - {{ compiler('c') }}
-        # cmake expects a C++ compiler for some reason
-        - {{ compiler('cxx') }}
-        # build-and-test.sh needs to find `Python.h`; can't do pin_subpackage
-        # due to the way conda-build (mis-)populates the package hashes
-        - python {{ version }} *_{{ PKG_BUILDNUM }}{{ debug }}_{{ abi_tag }}    # [unix]
-        - ripgrep
-        - cmake
-        - ninja
       commands:
         - VER=${PKG_VERSION%.*}    # [not win]
         - VERABI=${VER}            # [not win]
@@ -372,14 +363,6 @@ outputs:
         - if not exist %PREFIX%\python3.dll exit 1                   # [win]
         - if not exist %PREFIX%\python{{ ver2nd }}.dll exit 1        # [win]
         {% endif %}
-        - pushd tests
-        - pushd prefix-replacement  # [unix]
-        - bash build-and-test.sh    # [unix]
-        - popd                      # [unix]
-        - pushd cmake
-        - cmake -GNinja {{ cmake_test_args }} -DPY_VER={{ version }} -DEXTRA_COMPONENTS="Development.Embed" {{ cmake_debug }} .
-        - popd
-        - popd
 
   - name: libpython-static
     script: install_static.sh   # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}
@@ -322,11 +322,7 @@ outputs:
 
   - name: libpython
     script: install_shared.sh   # [unix]
-    files:                      # [win]
-      - python3.dll             # [win]
-      - python3t.dll            # [win]
-      - python{{ ver2nd }}.dll  # [win]
-      - python{{ ver2nd }}t.dll  # [win]
+    script: install_shared.bat  # [win]
     build:
       number: {{ build_number }}
       activate_in_script: true
@@ -352,7 +348,7 @@ outputs:
         - {{ compiler('cxx') }}
         # build-and-test.sh needs to find `Python.h`; can't do pin_subpackage
         # due to the way conda-build (mis-)populates the package hashes
-        - python {{ version }} *_{{ PKG_BUILDNUM }}{{ debug }}_{{ abi_tag }}
+        - python {{ version }} *_{{ PKG_BUILDNUM }}{{ debug }}_{{ abi_tag }}    # [unix]
         - ripgrep
         - cmake
         - ninja

--- a/recipe/tests/prefix-replacement/build-and-test.sh
+++ b/recipe/tests/prefix-replacement/build-and-test.sh
@@ -3,7 +3,7 @@
 set -ex
 
 case ${PKG_NAME} in
-  libpython)
+  python)
     # see bpo44182 for why -L${CONDA_PREFIX}/lib is added
     ${CC} a.c $(python3-config --cflags) \
         $(python3-config --embed --ldflags) \


### PR DESCRIPTION
Follow-up to #894. I noticed by chance that the `python3.dll` etc. did not actually end up in [`libpython`](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fwin-64%2Flibpython-3.14.7-h4f90d01_101_cp314.conda&with_broken=true).

That's despite tests to this effect
https://github.com/conda-forge/python-feedstock/blob/663c2af350b70a5d5771ff9788b6318dba71e2fd/recipe/meta.yaml#L372-L378
which however got satisfied spuriously by an additional test dependency
https://github.com/conda-forge/python-feedstock/blob/663c2af350b70a5d5771ff9788b6318dba71e2fd/recipe/meta.yaml#L353-L355

That dependency is a left-over from the `libpython` tests prior to the build order inversion in 636474b517b8f7ffe7dd4f7af0f2fa84497c0cd0. Now those tests make no sense on the `libpython` output anymore (causing us to shoehorn the full-fledged `python` back in to find e.g. `Python.h` and the executables, which also hides problems with the file-presence tests), so move them to `python`.