### PR TITLE
Publish 3.15.0rc1 to main channel; remove old `python3.1` symlink

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,8 +8,8 @@ jobs:
     vmImage: $(VMIMAGE)
   strategy:
     matrix:
-      osx_64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingno:
-        CONFIG: osx_64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingno
+      osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno:
+        CONFIG: osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
         build_workspace_dir: ~/miniforge3/conda-bld
@@ -18,8 +18,8 @@ jobs:
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
-      osx_64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingyes:
-        CONFIG: osx_64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingyes
+      osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes:
+        CONFIG: osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
         build_workspace_dir: ~/miniforge3/conda-bld
@@ -28,8 +28,8 @@ jobs:
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
-      osx_64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingno:
-        CONFIG: osx_64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingno
+      osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno:
+        CONFIG: osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
         build_workspace_dir: ~/miniforge3/conda-bld
@@ -38,8 +38,8 @@ jobs:
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
-      osx_64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingyes:
-        CONFIG: osx_64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingyes
+      osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes:
+        CONFIG: osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
         build_workspace_dir: ~/miniforge3/conda-bld
@@ -48,8 +48,8 @@ jobs:
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
-      osx_arm64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingno:
-        CONFIG: osx_arm64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingno
+      osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno:
+        CONFIG: osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
@@ -58,8 +58,8 @@ jobs:
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
-      osx_arm64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingyes:
-        CONFIG: osx_arm64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingyes
+      osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes:
+        CONFIG: osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
@@ -68,8 +68,8 @@ jobs:
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
-      osx_arm64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingno:
-        CONFIG: osx_arm64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingno
+      osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno:
+        CONFIG: osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
@@ -78,8 +78,8 @@ jobs:
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
-      osx_arm64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingyes:
-        CONFIG: osx_arm64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingyes
+      osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes:
+        CONFIG: osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld

--- a/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -1,27 +1,25 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 build_type:
 - debug
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '21'
+- '15'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev_debug
+- conda-forge python_debug
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '21'
+- '15'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 expat:
 - '2'
 freethreading:
@@ -32,8 +30,8 @@ liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-macos_machine:
-- arm64-apple-darwin20.0.0
+libuuid:
+- '2'
 ncurses:
 - '6'
 openssl:
@@ -47,7 +45,7 @@ python:
 readline:
 - '8'
 target_platform:
-- osx-arm64
+- linux-64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -1,39 +1,37 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 build_type:
-- release
+- debug
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '21'
+- '15'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge python_debug
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '21'
+- '15'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 expat:
 - '2'
 freethreading:
-- 'no'
+- 'yes'
 libffi:
 - '3.7'
 liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-macos_machine:
-- arm64-apple-darwin20.0.0
+libuuid:
+- '2'
 ncurses:
 - '6'
 openssl:
@@ -47,7 +45,7 @@ python:
 readline:
 - '8'
 target_platform:
-- osx-arm64
+- linux-64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -13,17 +13,17 @@ c_stdlib_version:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '15'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma10
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 expat:
 - '2'
 freethreading:
-- 'yes'
+- 'no'
 libffi:
 - '3.7'
 liblzma_devel:
@@ -45,7 +45,7 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-aarch64
+- linux-64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -1,5 +1,5 @@
 build_type:
-- release
+- debug
 bzip2:
 - '1'
 c_compiler:
@@ -9,21 +9,21 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.39'
+- '2.17'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge python_debug
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '15'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma10
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 expat:
 - '2'
 freethreading:
-- 'yes'
+- 'no'
 libffi:
 - '3.7'
 liblzma_devel:
@@ -45,7 +45,7 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-riscv64
+- linux-aarch64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -1,27 +1,25 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 build_type:
-- release
+- debug
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '21'
+- '15'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge python_debug
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '21'
+- '15'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 expat:
 - '2'
 freethreading:
@@ -32,8 +30,8 @@ liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+libuuid:
+- '2'
 ncurses:
 - '6'
 openssl:
@@ -47,7 +45,7 @@ python:
 readline:
 - '8'
 target_platform:
-- osx-64
+- linux-aarch64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -1,39 +1,37 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 build_type:
 - release
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '21'
+- '15'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '21'
+- '15'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 expat:
 - '2'
 freethreading:
-- 'yes'
+- 'no'
 libffi:
 - '3.7'
 liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-macos_machine:
-- arm64-apple-darwin20.0.0
+libuuid:
+- '2'
 ncurses:
 - '6'
 openssl:
@@ -47,7 +45,7 @@ python:
 readline:
 - '8'
 target_platform:
-- osx-arm64
+- linux-aarch64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -23,7 +23,7 @@ docker_image:
 expat:
 - '2'
 freethreading:
-- 'no'
+- 'yes'
 libffi:
 - '3.7'
 liblzma_devel:

--- a/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -1,5 +1,5 @@
 build_type:
-- release
+- debug
 bzip2:
 - '1'
 c_compiler:
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge python_debug
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -45,9 +45,7 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-64
-tk:
-- '8.6'
+- linux-ppc64le
 zip_keys:
 - - build_type
   - channel_targets

--- a/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -13,17 +13,17 @@ c_stdlib_version:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev_debug
+- conda-forge python_debug
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '15'
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma10
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 expat:
 - '2'
 freethreading:
-- 'no'
+- 'yes'
 libffi:
 - '3.7'
 liblzma_devel:
@@ -45,9 +45,7 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-aarch64
-tk:
-- '8.6'
+- linux-ppc64le
 zip_keys:
 - - build_type
   - channel_targets

--- a/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -1,39 +1,37 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 build_type:
 - release
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '21'
+- '15'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '21'
+- '15'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 expat:
 - '2'
 freethreading:
-- 'no'
+- 'yes'
 libffi:
 - '3.7'
 liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+libuuid:
+- '2'
 ncurses:
 - '6'
 openssl:
@@ -47,9 +45,7 @@ python:
 readline:
 - '8'
 target_platform:
-- osx-64
-tk:
-- '8.6'
+- linux-ppc64le
 zip_keys:
 - - build_type
   - channel_targets

--- a/.ci_support/linux_riscv64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/linux_riscv64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev_debug
+- conda-forge python_debug
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -23,7 +23,7 @@ docker_image:
 expat:
 - '2'
 freethreading:
-- 'yes'
+- 'no'
 libffi:
 - '3.7'
 liblzma_devel:

--- a/.ci_support/linux_riscv64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/linux_riscv64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -1,27 +1,25 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 build_type:
 - debug
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '21'
+- '15'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.39'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev_debug
+- conda-forge python_debug
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '21'
+- '15'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 expat:
 - '2'
 freethreading:
@@ -32,8 +30,8 @@ liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+libuuid:
+- '2'
 ncurses:
 - '6'
 openssl:
@@ -47,7 +45,7 @@ python:
 readline:
 - '8'
 target_platform:
-- osx-64
+- linux-riscv64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/linux_riscv64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/linux_riscv64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_riscv64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/linux_riscv64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -1,27 +1,25 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 build_type:
-- debug
+- release
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '21'
+- '15'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.39'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev_debug
+- conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '21'
+- '15'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 expat:
 - '2'
 freethreading:
@@ -32,8 +30,8 @@ liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-macos_machine:
-- arm64-apple-darwin20.0.0
+libuuid:
+- '2'
 ncurses:
 - '6'
 openssl:
@@ -47,7 +45,7 @@ python:
 readline:
 - '8'
 target_platform:
-- osx-arm64
+- linux-riscv64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -1,37 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 build_type:
-- release
+- debug
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '15'
+- '21'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge python_debug
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '15'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma10
+- '21'
 expat:
 - '2'
 freethreading:
-- 'yes'
+- 'no'
 libffi:
 - '3.7'
 liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-libuuid:
-- '2'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 ncurses:
 - '6'
 openssl:
@@ -45,7 +47,9 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-ppc64le
+- osx-64
+tk:
+- '8.6'
 zip_keys:
 - - build_type
   - channel_targets

--- a/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -1,37 +1,39 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 build_type:
 - debug
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '15'
+- '21'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.39'
+- '11.0'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev_debug
+- conda-forge python_debug
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '15'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma10
+- '21'
 expat:
 - '2'
 freethreading:
-- 'no'
+- 'yes'
 libffi:
 - '3.7'
 liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-libuuid:
-- '2'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 ncurses:
 - '6'
 openssl:
@@ -45,7 +47,7 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-riscv64
+- osx-64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -1,25 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 build_type:
-- debug
+- release
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '15'
+- '21'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev_debug
+- conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '15'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma10
+- '21'
 expat:
 - '2'
 freethreading:
@@ -30,8 +32,8 @@ liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-libuuid:
-- '2'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 ncurses:
 - '6'
 openssl:
@@ -45,7 +47,7 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-64
+- osx-64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -1,25 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 build_type:
-- debug
+- release
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '15'
+- '21'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev_debug
+- conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '15'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma10
+- '21'
 expat:
 - '2'
 freethreading:
@@ -30,8 +32,8 @@ liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-libuuid:
-- '2'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 ncurses:
 - '6'
 openssl:
@@ -45,7 +47,9 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-ppc64le
+- osx-64
+tk:
+- '8.6'
 zip_keys:
 - - build_type
   - channel_targets

--- a/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
+++ b/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno.yaml
@@ -1,25 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 build_type:
 - debug
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '15'
+- '21'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev_debug
+- conda-forge python_debug
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '15'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma10
+- '21'
 expat:
 - '2'
 freethreading:
@@ -30,8 +32,8 @@ liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-libuuid:
-- '2'
+macos_machine:
+- arm64-apple-darwin20.0.0
 ncurses:
 - '6'
 openssl:
@@ -45,7 +47,9 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-ppc64le
+- osx-arm64
+tk:
+- '8.6'
 zip_keys:
 - - build_type
   - channel_targets

--- a/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
+++ b/.ci_support/osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes.yaml
@@ -1,25 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 build_type:
 - debug
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '15'
+- '21'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev_debug
+- conda-forge python_debug
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '15'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma10
+- '21'
 expat:
 - '2'
 freethreading:
@@ -30,8 +32,8 @@ liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-libuuid:
-- '2'
+macos_machine:
+- arm64-apple-darwin20.0.0
 ncurses:
 - '6'
 openssl:
@@ -45,7 +47,7 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-64
+- osx-arm64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
+++ b/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '11.0'
 build_type:
-- debug
+- release
 bzip2:
 - '1'
 c_compiler:
@@ -17,7 +17,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev_debug
+- conda-forge main
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
@@ -33,7 +33,7 @@ liblzma_devel:
 libsqlite:
 - '3'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 ncurses:
 - '6'
 openssl:
@@ -47,7 +47,7 @@ python:
 readline:
 - '8'
 target_platform:
-- osx-64
+- osx-arm64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
+++ b/.ci_support/osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes.yaml
@@ -1,25 +1,27 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 build_type:
-- debug
+- release
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '15'
+- '21'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev_debug
+- conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '15'
-docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma10
+- '21'
 expat:
 - '2'
 freethreading:
@@ -30,8 +32,8 @@ liblzma_devel:
 - '5'
 libsqlite:
 - '3'
-libuuid:
-- '2'
+macos_machine:
+- arm64-apple-darwin20.0.0
 ncurses:
 - '6'
 openssl:
@@ -45,7 +47,7 @@ python:
 readline:
 - '8'
 target_platform:
-- linux-aarch64
+- osx-arm64
 tk:
 - '8.6'
 zip_keys:

--- a/.ci_support/win_64_freethreadingno.yaml
+++ b/.ci_support/win_64_freethreadingno.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge main
 cxx_compiler:
 - vs2022
 expat:

--- a/.ci_support/win_64_freethreadingyes.yaml
+++ b/.ci_support/win_64_freethreadingyes.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge main
 cxx_compiler:
 - vs2022
 expat:

--- a/.ci_support/win_arm64_freethreadingno.yaml
+++ b/.ci_support/win_arm64_freethreadingno.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge main
 cxx_compiler:
 - vs2022
 expat:

--- a/.ci_support/win_arm64_freethreadingyes.yaml
+++ b/.ci_support/win_arm64_freethreadingyes.yaml
@@ -9,7 +9,7 @@ c_stdlib:
 channel_sources:
 - conda-forge/label/python_rc,conda-forge
 channel_targets:
-- conda-forge python_dev
+- conda-forge main
 cxx_compiler:
 - vs2022
 expat:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -22,7 +22,7 @@ jobs:
       max-parallel: 50
       matrix:
         include:
-          - CONFIG: linux_64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingno
+          - CONFIG: linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -34,7 +34,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingyes
+          - CONFIG: linux_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -46,7 +46,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingno
+          - CONFIG: linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -58,7 +58,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingyes
+          - CONFIG: linux_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -70,7 +70,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_aarch64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingno
+          - CONFIG: linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -82,7 +82,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_aarch64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingyes
+          - CONFIG: linux_aarch64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -94,7 +94,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_aarch64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingno
+          - CONFIG: linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -106,7 +106,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_aarch64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingyes
+          - CONFIG: linux_aarch64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -118,7 +118,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingno
+          - CONFIG: linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -130,7 +130,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingyes
+          - CONFIG: linux_ppc64le_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -142,7 +142,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_ppc64le_build_typereleasechannel_targetsconda-forge_python_devfreethreadingno
+          - CONFIG: linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingno
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -154,7 +154,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_ppc64le_build_typereleasechannel_targetsconda-forge_python_devfreethreadingyes
+          - CONFIG: linux_ppc64le_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -166,7 +166,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_riscv64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingno
+          - CONFIG: linux_riscv64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -178,7 +178,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_riscv64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingyes
+          - CONFIG: linux_riscv64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -190,7 +190,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_riscv64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingno
+          - CONFIG: linux_riscv64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -202,7 +202,7 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
-          - CONFIG: linux_riscv64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingyes
+          - CONFIG: linux_riscv64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True

--- a/README.md
+++ b/README.md
@@ -66,59 +66,59 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>osx_64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingno</td>
+              <td>osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingno" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingyes</td>
+              <td>osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingyes" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingno</td>
+              <td>osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingno" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingyes</td>
+              <td>osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingyes" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingno</td>
+              <td>osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingno" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingno" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingyes</td>
+              <td>osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_build_typedebugchannel_targetsconda-forge_python_dev_debugfreethreadingyes" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_build_typedebugchannel_targetsconda-forge_python_debugfreethreadingyes" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingno</td>
+              <td>osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingno" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingno" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingyes</td>
+              <td>osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4155&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_build_typereleasechannel_targetsconda-forge_python_devfreethreadingyes" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/python-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_build_typereleasechannel_targetsconda-forge_mainfreethreadingyes" alt="variant">
                 </a>
               </td>
             </tr>
@@ -145,10 +145,10 @@ Current release info
 Installing python
 =================
 
-Installing `python` from the `conda-forge/label/python_dev_debug` channel can be achieved by adding `conda-forge/label/python_dev_debug` to your channels with:
+Installing `python` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
-conda config --add channels conda-forge/label/python_dev_debug
+conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
@@ -194,7 +194,7 @@ It is possible to list all of the versions of `cpython` available on your platfo
 <summary>With conda</summary>
 
 ```
-conda search cpython --channel conda-forge/label/python_dev_debug
+conda search cpython --channel conda-forge
 ```
 
 </details>
@@ -203,7 +203,7 @@ conda search cpython --channel conda-forge/label/python_dev_debug
 <summary>With mamba</summary>
 
 ```
-mamba search cpython --channel conda-forge/label/python_dev_debug
+mamba search cpython --channel conda-forge
 ```
 
 </details>
@@ -212,7 +212,7 @@ mamba search cpython --channel conda-forge/label/python_dev_debug
 <summary>With pixi</summary>
 
 ```
-pixi search cpython --channel conda-forge/label/python_dev_debug
+pixi search cpython --channel conda-forge
 ```
 
 </details>
@@ -222,13 +222,13 @@ pixi search cpython --channel conda-forge/label/python_dev_debug
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search cpython --channel conda-forge/label/python_dev_debug
+mamba repoquery search cpython --channel conda-forge
 
 # List packages depending on `cpython`:
-mamba repoquery whoneeds cpython --channel conda-forge/label/python_dev_debug
+mamba repoquery whoneeds cpython --channel conda-forge
 
 # List dependencies of `cpython`:
-mamba repoquery depends cpython --channel conda-forge/label/python_dev_debug
+mamba repoquery depends cpython --channel conda-forge
 ```
 
 </details>

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -418,8 +418,6 @@ if [[ -f ${PREFIX}/bin/python${VER}m ]]; then
 fi
 ln -s ${PREFIX}/bin/python${VER} ${PREFIX}/bin/python
 ln -s ${PREFIX}/bin/pydoc${VER} ${PREFIX}/bin/pydoc
-# Workaround for https://github.com/conda/conda/issues/10969
-ln -s ${PREFIX}/bin/python${VER} ${PREFIX}/bin/python3.1
 
 # Remove test data to save space
 # Though keep `support` as some things use that.
@@ -525,8 +523,7 @@ fi
 
 # Workaround for https://github.com/conda/conda/issues/14053
 # Older conda versions install noarch: python packages in wrong places.
-# For example python3.1 because older conda assumed python minor version
-# will have only one digit. noarhc pkgs for freethreading builds are supposed
+# noarch pkgs for freethreading builds are supposed
 # to be installed into <prefix>/lib/python3.13t/site-packages, but conda
 # installs them to <prefix>/lib/python3.13/site-packages.
 # The workaround is to add all these wrong paths to sys.path using
@@ -539,8 +536,6 @@ SP_DIR="${PREFIX}/lib/python${PY_VER}${THREAD}/site-packages"
 if [[ ${PY_FREETHREADING} == yes ]]; then
     echo "${PREFIX}/lib/python${PY_VER}/site-packages" >> $SP_DIR/conda-site.pth
 fi
-# Workaround for https://github.com/conda/conda/issues/10969
-echo "${PREFIX}/lib/python3.1/site-packages" >> $SP_DIR/conda-site.pth
 # A python version independent directory that ABI3 and noarch packages can use.
 # This is unused at the moment, but keeping it here for experimentation.
 echo "${PREFIX}/lib/python/site-packages" >> $SP_DIR/conda-site.pth

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -28,8 +28,8 @@ build_type:
   - release
   - debug                      # [not win]
 channel_targets:
-  - conda-forge python_dev
-  - conda-forge python_dev_debug   # [not win]
+  - conda-forge main
+  - conda-forge python_debug   # [not win]
 zip_keys:
   - build_type
   - channel_targets

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set ver2 = '.'.join(version.split('.')[0:2]) %}
 {% set ver2nd = ''.join(version.split('.')[0:2]) %}
 {% set ver3nd = ''.join(version.split('.')[0:3]) %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 # this makes the linter happy
 {% set channel_targets = channel_targets or 'conda-forge main' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -183,37 +183,37 @@ outputs:
         - clang 21.*       # [win]
         - llvm-tools 21.*  # [win]
         - bzip2            # [build_platform != target_platform]
-        - libsqlite        # [build_platform != target_platform]
+        - expat            # [build_platform != target_platform]
+        - libffi           # [build_platform != target_platform]
         - liblzma-devel    # [build_platform != target_platform]
+        - libmpdec-devel   # [build_platform != target_platform]
+        - libsqlite        # [build_platform != target_platform]
+        - libuuid          # [build_platform != target_platform and linux]
+        - libxcrypt        # [build_platform != target_platform and linux]
+        - ncurses          # [build_platform != target_platform and unix]
+        - openssl          # [build_platform != target_platform]
+        - readline         # [build_platform != target_platform and unix]
+        - tk               # [build_platform != target_platform]
         - zlib             # [build_platform != target_platform]
         - zstd             # [build_platform != target_platform]
-        - openssl          # [build_platform != target_platform]
-        - readline         # [not win and build_platform != target_platform]
-        - tk               # [build_platform != target_platform]
-        - ncurses          # [unix and build_platform != target_platform]
-        - libffi           # [build_platform != target_platform]
-        - libuuid          # [linux and build_platform != target_platform]
-        - libxcrypt        # [linux and build_platform != target_platform]
-        - libmpdec-devel   # [build_platform != target_platform]
-        - expat            # [build_platform != target_platform]
       host:
         - bzip2
-        - libsqlite
+        - expat
+        - ld_impl_{{ target_platform }} >=2.36.1  # [linux]
+        - libffi
         - liblzma-devel
-        - zlib
-        - zstd
+        - libmpdec-devel
+        - libuuid           # [linux]
+        - libsqlite
+        - ncurses           # [unix]
         - openssl
-        - readline  # [not win]
+        - readline          # [unix]
         - tk
         # These two are just to get the headers needed for tk.h, but is unused
         - xorg-libx11       # [unix]
         - xorg-xorgproto    # [unix]
-        - ncurses  # [unix]
-        - libffi
-        - ld_impl_{{ target_platform }} >=2.36.1  # [linux]
-        - libuuid  # [linux]
-        - libmpdec-devel
-        - expat
+        - zlib
+        - zstd
       run:
         - ld_impl_{{ target_platform }} >=2.36.1  # [linux]
         - tzdata

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -301,6 +301,7 @@ outputs:
         # Test for wide character supported via ncursesw
         - TERM=xterm >/dev/null python -c "import curses; scr = curses.initscr(); curses.unget_wch('x'); assert 'x' ==  scr.get_wch()"  # [unix]
 
+  # this output is empty on windows
   - name: libpython
     script: install_shared.sh   # [unix]
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -245,8 +245,6 @@ outputs:
       commands:
         - echo on  # [win]
         - set  # [win]
-        # ensure we don't pick up python from the image by accident
-        - rmdir /s /q C:\hostedtoolcache\windows\Python  # [win]
         - python -V
         - python3 -V            # [not win]
         - pydoc -h

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -293,7 +293,6 @@ outputs:
         - popd
         - python run_test.py
         - test ! -f default.profraw   # [osx]
-        - python3.1 --version  # [unix]
         # Test for segfault on osx-64 with libffi=3.4, see https://bugs.python.org/issue44556
         - python -c "from ctypes import CFUNCTYPE; CFUNCTYPE(None)(id)"
         # Test for wide character supported via ncursesw


### PR DESCRIPTION
There was one crucial thing I forgot in #908: publish the builds to the `main` channel again. In the meantime, pick up some useful bits and pieces:
* 64b26eb40d121454f06f0f13e266ed380291e090 from #909 
* 2ca75324b1892259296ec7f9cc640acca5a7901e from #911
* Fix #910 
* the moral equivalent of the dependency clean-ups in 636474b517b8f7ffe7dd4f7af0f2fa84497c0cd0 (which had to be reverted for [#908](https://github.com/conda-forge/python-feedstock/pull/908))